### PR TITLE
23.02.2022

### DIFF
--- a/src/POLARES.cpp
+++ b/src/POLARES.cpp
@@ -1,4 +1,4 @@
-//-------------------------------------------------------------------------------------------------
+//------------------------------------------------------------------------------------------------
 // POLARES (Radiative Corrections to Polarized Electron-Proton Scattering)
 // is a free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by the
@@ -7,7 +7,10 @@
 //	R.-D. Bucoveanu and H. Spiesberger, Eur. Phys. J. A (2019) 55: 57
 //	arXiv:1811.04970 [hep-ph].
 // Copyright (c) Razvan Bucoveanu, 2019. E-mail: rabucove@uni-mainz.de
-//=================================================================================================
+//
+// Modified: 24.02.-05.03.2022 by HS
+//
+//================================================================================================
 #include "POLARES.h" // Main header file
 #include <cuba.h>
 #include <iostream>
@@ -15,7 +18,7 @@
 #include "const.h"
 #include <stdlib.h>
 #include "config.h"
-//----------------------------------------------------------------------------------------------
+//------------------------------------------------------------------------------------------------
 
 using namespace POLARES;
 using namespace constants;
@@ -38,6 +41,7 @@ void PES::set_input(const Input& input){
 	M = param.M;
 	M2 = pow(M,2.);
 
+// Prepare to include hadronic vacuum polarization
 	if (param.flag[param.vac_pol] == 3) {
 		std::ifstream ifvpol("share/vp_Ignatov.dat");
 		if (!ifvpol) {
@@ -65,6 +69,7 @@ void PES::set_input(const Input& input){
 		}
 		interpolation.init_d_vac_hadr("share/vp_knt18.dat");
 	}
+// Prepare to include two-photon-exchange corrections
 	if (param.flag[param.tpe] == 2) {
 			std::ifstream iftpe("share/tpe_fwd.dat");
 			if (!iftpe) {
@@ -83,28 +88,8 @@ void PES::set_input(const Input& input){
 			}
 			interpolation.init_tpe_Tomalak("share/tpe_bwd.dat");
 		}
-
-//	if (param.flag[param.tpe] == 1) {
-//		if (param.flag[param.IS] == 1) {
-//			std::ifstream iftpe1("share/tpe1.dat");
-//			if (!iftpe1) {
-//				std::cerr<<"Error: 'tpe1.dat' cannot be found! "
-//						"Please copy it in the folder named 'share'.\n\n";
-//				exit (EXIT_FAILURE);
-//			}
-//			interpolation.init_tpe("share/tpe1.dat");
-//		}
-//		else if (param.flag[param.IS] == 2) {
-//			std::ifstream iftpe2("share/tpe2.dat");
-//			if (!iftpe2) {
-//				std::cerr<<"Error: 'tpe2.dat' cannot be found! "
-//						"Please copy it in the folder named 'share'.\n\n";
-//				exit (EXIT_FAILURE);
-//			}
-//			interpolation.init_tpe("share/tpe2.dat");
-//		}
-//	}
 }
+
 
 int PES::initialization(){
 
@@ -121,56 +106,85 @@ int PES::initialization(){
 	double sigma_hp_2nd_l1k1_error, sigma_hp_2nd_l1k2_error, sigma_hp_2nd_l2k1_error,
 	sigma_hp_2nd_l2k2_error;
 
+
+// Proton target
 	if (param.flag[param.target] == 0) {
 
+
+// Leading order only
 	if (param.flag[param.LO] == 1) {
-
-		std::cout << "Numerical integration for the LO unpolarized cross-section ... ";
-
+		std::cout << "Integration for the LO unpolarized cross section ... ";
 		if (param.flag[param.int_method] == 0) {
-
 		llVegas(CP.NDIM_ELASTIC, CP.NCOMP, integrands.cuba_integrand_born,
 				USERDATA, CP.NVEC, CP.EPSREL, CP.EPSABS, CP.flags, CP.SEED,
 				CP.MINEVAL, CP.MAXEVAL_LO, CP.NSTART, CP.NINCREASE, CP.NBATCH,
 				CP.GRIDNO, CP.STATEFILE, CP.SPIN,
 				&CP.neval, &CP.fail, integral, error, prob);
 		}
-
 		if (param.flag[param.int_method] == 1) {
-
 				llSuave(CP.NDIM_ELASTIC, CP.NCOMP, integrands.cuba_integrand_born,
 						USERDATA, CP.NVEC, CP.EPSREL, CP.EPSABS, CP.flags | 4, CP.SEED,
 						CP.MINEVAL, CP.MAXEVAL_LO, CP.NNEW, CP.NMIN, CP.FLATNESS,
 						CP.STATEFILE, CP.SPIN,
 						&CP.nregions, &CP.neval, &CP.fail, integral, error, prob);
 		}
-
 		std::cout <<"completed\n";
-
 		output.sigma_unpol_born = integral[CP.comp]*nb;
 		errors.sigma_unpol_born = error[CP.comp]*nb;
-	}
 
+        if (param.flag[param.asymmetry] == 1) {
+            std::cout << "Integration for the LO polarized cross section ... ";
+            llVegas(CP.NDIM_ELASTIC, CP.NCOMP, integrands.cuba_integrand_interf_born,
+                    USERDATA, CP.NVEC, CP.EPSREL, CP.EPSABS, CP.flags, CP.SEED,
+                    CP.MINEVAL, CP.MAXEVAL_LO, CP.NSTART, CP.NINCREASE, CP.NBATCH,
+                    CP.GRIDNO, CP.STATEFILE, CP.SPIN,
+                    &CP.neval, &CP.fail, integral, error, prob);
+            output.sigma_pol_born = param.P*integral[CP.comp]*nb;
+            errors.sigma_pol_born = param.P*error[CP.comp]*nb;
+            output.asymm_born = output.sigma_pol_born / output.sigma_unpol_born;
+            errors.asymm_born = abs(output.sigma_pol_born/output.sigma_unpol_born) *
+                    sqrt(pow(errors.sigma_unpol_born/output.sigma_unpol_born,2.)
+                            + pow(errors.sigma_pol_born/output.sigma_pol_born,2.));
+            output.sigma_born = output.sigma_pol_born + output.sigma_unpol_born;
+            errors.sigma_born = sqrt(pow(errors.sigma_pol_born,2.) + 
+                                     pow(errors.sigma_unpol_born,2.));
+            std::cout <<"completed\n";
+        }
+    }
+// End section for leading order only
+
+
+// Non-radiative (elastic) cross section: 
+// leading order + loop + soft photon  
+// for both first order or first+second order 
+// and including vacpol and hadronic corrections if requested
 	if (param.flag[param.order] >= 0) {
-
-		std::cout << "Numerical integration for the soft-photon unpolarized cross-section ... ";
-
+		std::cout << "Integration for soft-photon + loop unpolarized cross section ... ";
 		llVegas(CP.NDIM_ELASTIC, CP.NCOMP, integrands.cuba_integrand_elastic,
 				USERDATA, CP.NVEC, CP.EPSREL, CP.EPSABS, CP.flags, CP.SEED,
 				CP.MINEVAL, CP.MAXEVAL_LO, CP.NSTART, CP.NINCREASE, CP.NBATCH,
 				CP.GRIDNO_elastic, CP.STATEFILE, CP.SPIN,
 				&CP.neval, &CP.fail, integral, error, prob);
-
 		if (param.flag[param.order] == 0 || param.flag[param.order] == 1) {
-			errors.sigma_unpol_elastic_1st = error[CP.comp]*nb;
 			output.sigma_unpol_elastic_1st = integral[CP.comp]*nb;
+            errors.sigma_unpol_elastic_1st = error[CP.comp]*nb;
 		}
-
 		if (param.flag[param.order] == 2) {
-			errors.sigma_unpol_elastic_2nd = error[CP.comp]*nb;
 			output.sigma_unpol_elastic_2nd = integral[CP.comp]*nb;
+            errors.sigma_unpol_elastic_2nd = error[CP.comp]*nb;
+// ... but we want to keep track of the 1st order corrections: 
+// reset order and repeat the calculation 
+            param.flag[param.order] = 1;
+            llVegas(CP.NDIM_ELASTIC, CP.NCOMP, integrands.cuba_integrand_elastic,
+                    USERDATA, CP.NVEC, CP.EPSREL, CP.EPSABS, CP.flags, CP.SEED,
+                    CP.MINEVAL, CP.MAXEVAL_LO, CP.NSTART, CP.NINCREASE, CP.NBATCH,
+                    CP.GRIDNO_elastic, CP.STATEFILE, CP.SPIN,
+                    &CP.neval, &CP.fail, integral, error, prob);
+            output.sigma_unpol_elastic_1st = integral[CP.comp]*nb;
+            errors.sigma_unpol_elastic_1st = error[CP.comp]*nb;
+            param.flag[param.order] = 2;
+// done recalculation of 1st order elastic cross section 
 		}
-
 		if (param.flag[param.brems] == 0 && param.flag[param.brems_hadr] == 0) {
 			output.sigma_unpol_1st = output.sigma_unpol_elastic_1st;
 			errors.sigma_unpol_1st = errors.sigma_unpol_elastic_1st;
@@ -178,124 +192,102 @@ int PES::initialization(){
 			errors.sigma_unpol_2nd = errors.sigma_unpol_elastic_2nd;
 		}
 		std::cout <<"completed\n";
-	}
 
-	if (param.flag[param.asymmetry] == 1) {
-		if (param.flag[param.LO] == 1) {
-
-			std::cout << "Numerical integration for the LO polarized cross-section ... ";
-
-			llVegas(CP.NDIM_ELASTIC, CP.NCOMP, integrands.cuba_integrand_interf_born,
-					USERDATA, CP.NVEC, CP.EPSREL, CP.EPSABS, CP.flags, CP.SEED,
-					CP.MINEVAL, CP.MAXEVAL_LO, CP.NSTART, CP.NINCREASE, CP.NBATCH,
-					CP.GRIDNO, CP.STATEFILE, CP.SPIN,
-					&CP.neval, &CP.fail, integral, error, prob);
-
-
-			output.sigma_pol_born = param.P*integral[CP.comp]*nb;
-			errors.sigma_pol_born = param.P*error[CP.comp]*nb;
-			output.asymm_born = output.sigma_pol_born / output.sigma_unpol_born;
-			errors.asymm_born = (output.sigma_pol_born/output.sigma_unpol_born) *
-					sqrt(pow(errors.sigma_unpol_born/output.sigma_unpol_born,2.)
-							+ pow(errors.sigma_pol_born/output.sigma_pol_born,2.));
-			output.sigma_born = output.sigma_pol_born + output.sigma_unpol_born;
-			errors.sigma_born = sqrt(pow(errors.sigma_pol_born,2.) + pow(errors.sigma_unpol_born,2.));
-
-			std::cout <<"completed\n";
-		}
-
-		if (param.flag[param.order] >= 0) {
-
-			std::cout << "Numerical integration for the soft-photon polarized cross-section ... ";
-
+        if (param.flag[param.asymmetry] == 1) {
+			std::cout << "Integration for soft-photon + loop polarized cross section ... ";
 			llVegas(CP.NDIM_ELASTIC, CP.NCOMP, integrands.cuba_integrand_interf_elastic,
 					USERDATA, CP.NVEC, CP.EPSREL, CP.EPSABS, CP.flags, CP.SEED,
 					CP.MINEVAL, CP.MAXEVAL_LO, CP.NSTART, CP.NINCREASE, CP.NBATCH,
 					CP.GRIDNO, CP.STATEFILE, CP.SPIN,
 					&CP.neval, &CP.fail, integral, error, prob);
-
 			if (param.flag[param.order] == 0 || param.flag[param.order] == 1) {
-				errors.sigma_pol_elastic_1st = param.P*error[CP.comp]*nb;
 				output.sigma_pol_elastic_1st = param.P*integral[CP.comp]*nb;
-			}
-
+                errors.sigma_pol_elastic_1st = param.P*error[CP.comp]*nb;
+            }
 			if (param.flag[param.order] == 2) {
-				errors.sigma_pol_elastic_2nd = param.P*error[CP.comp]*nb;
 				output.sigma_pol_elastic_2nd = param.P*integral[CP.comp]*nb;
+                errors.sigma_pol_elastic_2nd = param.P*error[CP.comp]*nb; 
+// keep track of the 1st order corrections: 
+// reset order and repeat the calculation 
+                param.flag[param.order] = 1;
+                llVegas(CP.NDIM_ELASTIC, CP.NCOMP, integrands.cuba_integrand_interf_elastic,
+                        USERDATA, CP.NVEC, CP.EPSREL, CP.EPSABS, CP.flags, CP.SEED,
+                        CP.MINEVAL, CP.MAXEVAL_LO, CP.NSTART, CP.NINCREASE, CP.NBATCH,
+                        CP.GRIDNO, CP.STATEFILE, CP.SPIN,
+                        &CP.neval, &CP.fail, integral, error, prob);
+                output.sigma_pol_elastic_1st = param.P*integral[CP.comp]*nb;
+                errors.sigma_pol_elastic_1st = param.P*error[CP.comp]*nb;
+                param.flag[param.order] = 2;
+// done recalculation of 1st order elastic cross section 
 			}
-
 			if (param.flag[param.brems] == 0) {
 				output.sigma_pol_1st = output.sigma_pol_elastic_1st;
 				errors.sigma_pol_1st = errors.sigma_pol_elastic_1st;
 				output.sigma_pol_2nd = output.sigma_pol_elastic_2nd;
 				errors.sigma_pol_2nd = errors.sigma_pol_elastic_2nd;
 				output.sigma_1st = output.sigma_pol_1st + output.sigma_unpol_1st;
-				errors.sigma_1st = sqrt(pow(errors.sigma_pol_1st,2.) + pow(errors.sigma_unpol_1st,2.));
+				errors.sigma_1st = sqrt(pow(errors.sigma_pol_1st,2.) + 
+                                        pow(errors.sigma_unpol_1st,2.));
 				output.sigma_2nd = output.sigma_pol_2nd + output.sigma_unpol_2nd;
-				errors.sigma_2nd = sqrt(pow(errors.sigma_pol_2nd,2.) + pow(errors.sigma_unpol_2nd,2.));
+				errors.sigma_2nd = sqrt(pow(errors.sigma_pol_2nd,2.) + 
+                                        pow(errors.sigma_unpol_2nd,2.));
+                output.asymm_1st = output.sigma_pol_1st / output.sigma_unpol_1st;
+                errors.asymm_1st = abs(output.sigma_pol_1st/output.sigma_unpol_1st) *
+                        sqrt(pow(errors.sigma_unpol_1st/output.sigma_unpol_1st,2.)
+                                + pow(errors.sigma_pol_1st/output.sigma_pol_1st,2.));
+                output.rel_asymm_1st = - 100.*(output.asymm_1st - output.asymm_born) / 
+                                              output.asymm_born;
+                output.asymm_2nd = output.sigma_pol_2nd / output.sigma_unpol_2nd;
+                errors.asymm_2nd = abs(output.sigma_pol_2nd/output.sigma_unpol_2nd) *
+                        sqrt(pow(errors.sigma_unpol_2nd/output.sigma_unpol_2nd,2.)
+                                + pow(errors.sigma_pol_2nd/output.sigma_pol_2nd,2.));
+                output.rel_asymm_2nd = - 100.*(output.asymm_2nd - output.asymm_born) / 
+                                              output.asymm_born;
 			}
-		}
-
-		std::cout <<"completed\n";
-
+            std::cout <<"completed\n";
+        }
 	}
+// End section for leptonic non-radiative cross section
 
+
+// Radiative contributions: One hard photon radiation 
+// At first order: just one-photon bremsstrahlung 
+// at second order: including loop and soft-photon correction to one-photon bremsstrahlung
 	if (param.flag[param.brems] == 1 || param.flag[param.brems] == 2) {
-
-		std::cout << "Numerical integration for one hard-photon unpolarized cross-section ... ";
-
+		std::cout << "Integration for one hard-photon unpolarized cross section ... ";
 		if (param.flag[param.int_method] == 0) {
-
 			if (param.flag[param.PS] == 0) {
 				llVegas(CP.NDIM_brems_1st, CP.NCOMP, integrands.cuba_integrand_brems_1st,
 						USERDATA, CP.NVEC, CP.EPSREL, CP.EPSABS, CP.flags, CP.SEED,
 						CP.MINEVAL, 1e7, CP.NSTART, CP.NINCREASE, CP.NBATCH,
 						CP.GRIDNO_brems_1st, CP.STATEFILE, CP.SPIN,
 						&CP.neval, &CP.fail, integral, error, prob);
-
 				llVegas(CP.NDIM_brems_1st, CP.NCOMP, integrands.cuba_integrand_brems_1st,
 						USERDATA, CP.NVEC, CP.EPSREL, CP.EPSABS, CP.flags_brems, CP.SEED,
 						CP.MINEVAL, CP.MAXEVAL_1st, CP.NSTART, CP.NINCREASE, CP.NBATCH,
 						CP.GRIDNO_brems_1st, CP.STATEFILE, CP.SPIN,
 						&CP.neval, &CP.fail, integral, error, prob);
 			}
-
 			if (param.flag[param.PS] == 1) {
 				llVegas(CP.NDIM_brems_1st, CP.NCOMP, integrands.cuba_integrand_brems_1st_ps2,
 						USERDATA, CP.NVEC, CP.EPSREL, CP.EPSABS, CP.flags, CP.SEED,
 						CP.MINEVAL, 1e7, CP.NSTART, CP.NINCREASE, CP.NBATCH,
 						CP.GRIDNO_brems_1st, CP.STATEFILE, CP.SPIN,
 						&CP.neval, &CP.fail, integral, error, prob);
-
 				llVegas(CP.NDIM_brems_1st, CP.NCOMP, integrands.cuba_integrand_brems_1st_ps2,
 						USERDATA, CP.NVEC, CP.EPSREL, CP.EPSABS, CP.flags_brems, CP.SEED,
 						CP.MINEVAL, CP.MAXEVAL_1st, CP.NSTART, CP.NINCREASE, CP.NBATCH,
 						CP.GRIDNO_brems_1st, CP.STATEFILE, CP.SPIN,
 						&CP.neval, &CP.fail, integral, error, prob);
-
-//				llVegas(CP.NDIM_brems_1st, CP.NCOMP, integrands.cuba_integrand_brems_1st_test,
-//						USERDATA, CP.NVEC, CP.EPSREL, CP.EPSABS, CP.flags, CP.SEED,
-//						CP.MINEVAL, 1e7, CP.NSTART, CP.NINCREASE, CP.NBATCH,
-//						CP.GRIDNO_brems_1st, CP.STATEFILE, CP.SPIN,
-//						&CP.neval, &CP.fail, integral, error, prob);
-//
-//				llVegas(CP.NDIM_brems_1st, CP.NCOMP, integrands.cuba_integrand_brems_1st_test,
-//						USERDATA, CP.NVEC, CP.EPSREL, CP.EPSABS, CP.flags_brems, CP.SEED,
-//						CP.MINEVAL, CP.MAXEVAL_1st, CP.NSTART, CP.NINCREASE, CP.NBATCH,
-//						CP.GRIDNO_brems_1st, CP.STATEFILE, CP.SPIN,
-//						&CP.neval, &CP.fail, integral, error, prob);
 			}
 		}
-
 		if (param.flag[param.int_method] == 1) {
-
 			if (param.flag[param.PS] == 0) {
 				llSuave(CP.NDIM_brems_1st, CP.NCOMP, integrands.cuba_integrand_brems_1st,
 						USERDATA, CP.NVEC, CP.EPSREL, CP.EPSABS, CP.flags_brems | 4, CP.SEED,
 						CP.MINEVAL, CP.MAXEVAL_1st, CP.NNEW, CP.NMIN, CP.FLATNESS,
 						CP.STATEFILE, CP.SPIN,
 						&CP.nregions, &CP.neval, &CP.fail, integral, error, prob);
-
 			}
 
 			if (param.flag[param.PS] == 1) {
@@ -306,9 +298,7 @@ int PES::initialization(){
 						&CP.nregions, &CP.neval, &CP.fail, integral, error, prob);
 			}
 		}
-
 		if (param.flag[param.int_method] == 2) {
-
 			if (param.flag[param.PS] == 0) {
 				llCuhre(CP.NDIM_brems_1st, CP.NCOMP, integrands.cuba_integrand_brems_1st,
 						USERDATA, CP.NVEC, CP.EPSREL, CP.EPSABS, CP.flags_brems | 4,
@@ -316,7 +306,6 @@ int PES::initialization(){
 						CP.STATEFILE, CP.SPIN,
 						&CP.nregions, &CP.neval, &CP.fail, integral, error, prob);
 			}
-
 			if (param.flag[param.PS] == 1) {
 				llCuhre(CP.NDIM_brems_1st, CP.NCOMP, integrands.cuba_integrand_brems_1st_ps2,
 						USERDATA, CP.NVEC, CP.EPSREL, CP.EPSABS, CP.flags_brems | 4,
@@ -325,49 +314,44 @@ int PES::initialization(){
 						&CP.nregions, &CP.neval, &CP.fail, integral, error, prob);
 			}
 		}
-
 		if (param.flag[param.order] == 0) {
 			output.sigma_unpol_inelastic_1st = integral[CP.comp]*nb;
 			errors.sigma_unpol_inelastic_1st = error[CP.comp]*nb;
 		}
-
-		if (param.flag[param.order] == 1) {
+		if (param.flag[param.order] == 1 || param.flag[param.order] == 2) {
 			output.sigma_unpol_inelastic_1st = integral[CP.comp]*nb;
 			errors.sigma_unpol_inelastic_1st = error[CP.comp]*nb;
-			output.sigma_unpol_1st = output.sigma_unpol_inelastic_1st + output.sigma_unpol_elastic_1st;
-			errors.sigma_unpol_1st = sqrt(pow(errors.sigma_unpol_inelastic_1st,2.)
-					+ pow(errors.sigma_unpol_elastic_1st,2.));
+			output.sigma_unpol_1st = output.sigma_unpol_inelastic_1st + 
+                                     output.sigma_unpol_elastic_1st;
+			errors.sigma_unpol_1st = sqrt(pow(errors.sigma_unpol_inelastic_1st,2.) + 
+                                          pow(errors.sigma_unpol_elastic_1st,2.));
 		}
-
 		if (param.flag[param.order] == 2) {
 			output.sigma_unpol_inelastic_loop = integral[CP.comp]*nb;
 			errors.sigma_unpol_inelastic_loop = error[CP.comp]*nb;
 		}
 		std::cout <<"completed\n";
 	}
+// End section for one-photon bremsstrahlung
 
-	if (param.flag[param.hadr_corr] == 1 || param.flag[param.hadr_corr] == 3) {
 
-		std::cout << "Numerical integration for the hadronic interference part of one hard-photon unpolarized cross-section ... ";
-
+// Hadronic bremsstrahlung corrections (1st order only)
+	if (param.flag[param.brems_hadr] == 1 || param.flag[param.brems_hadr] == 3) {
+		std::cout << 
+        "Integration for hadronic interference hard-photon unpolarized cross section ... ";
 		if (param.flag[param.int_method] == 0) {
-
 			llVegas(CP.NDIM_brems_1st, CP.NCOMP, integrands.cuba_integrand_brems_1st_hadr_interf,
 					USERDATA, CP.NVEC, CP.EPSREL, CP.EPSABS, CP.flags, CP.SEED,
 					CP.MINEVAL, 1e7, CP.NSTART, CP.NINCREASE, CP.NBATCH,
 					CP.GRIDNO_brems_hadr_interf, CP.STATEFILE, CP.SPIN,
 					&CP.neval, &CP.fail, integral, error, prob);
-
 			llVegas(CP.NDIM_brems_1st, CP.NCOMP, integrands.cuba_integrand_brems_1st_hadr_interf,
 					USERDATA, CP.NVEC, CP.EPSREL, CP.EPSABS, CP.flags_brems, CP.SEED,
 					CP.MINEVAL, CP.MAXEVAL_1st, CP.NSTART, CP.NINCREASE, CP.NBATCH,
 					CP.GRIDNO_brems_hadr_interf, CP.STATEFILE, CP.SPIN,
 					&CP.neval, &CP.fail, integral, error, prob);
-
 		}
-
 		if (param.flag[param.int_method] == 1) {
-
 			llSuave(CP.NDIM_brems_1st, CP.NCOMP, integrands.cuba_integrand_brems_1st_hadr_interf,
 					USERDATA, CP.NVEC, CP.EPSREL, CP.EPSABS, CP.flags_brems | 4, CP.SEED,
 					CP.MINEVAL, CP.MAXEVAL_1st, CP.NNEW, CP.NMIN, CP.FLATNESS,
@@ -377,80 +361,156 @@ int PES::initialization(){
 		}
 		output.sigma_unpol_inelastic_1st_hadr_interf = integral[CP.comp]*nb;
 		errors.sigma_unpol_inelastic_1st_hadr_interf = error[CP.comp]*nb;
-
 		if (param.flag[param.order] == 0 || param.flag[param.order] == 1) {
 			output.sigma_unpol_inelastic_1st += output.sigma_unpol_inelastic_1st_hadr_interf;
-			errors.sigma_unpol_inelastic_1st = sqrt(pow(errors.sigma_unpol_inelastic_1st,2.)
-												+ pow(errors.sigma_unpol_inelastic_1st_hadr_interf,2.));
-			output.sigma_unpol_1st = output.sigma_unpol_inelastic_1st + output.sigma_unpol_elastic_1st;
-			errors.sigma_unpol_1st = sqrt(pow(errors.sigma_unpol_inelastic_1st,2.)
-					+ pow(errors.sigma_unpol_elastic_1st,2.));
+			errors.sigma_unpol_inelastic_1st = sqrt(pow(errors.sigma_unpol_inelastic_1st,2.) + 
+                                            pow(errors.sigma_unpol_inelastic_1st_hadr_interf,2.));
+			output.sigma_unpol_1st = output.sigma_unpol_inelastic_1st + 
+                                     output.sigma_unpol_elastic_1st;
+			errors.sigma_unpol_1st = sqrt(pow(errors.sigma_unpol_inelastic_1st,2.) + 
+                                          pow(errors.sigma_unpol_elastic_1st,2.));
 		}
-
 		if (param.flag[param.order] == 2) {
-			output.sigma_unpol_inelastic_loop +=  output.sigma_unpol_inelastic_1st_hadr_interf;
-			errors.sigma_unpol_inelastic_loop = sqrt(pow(errors.sigma_unpol_inelastic_1st,2.)
-												+ pow(errors.sigma_unpol_inelastic_1st_hadr_interf,2.));
+			output.sigma_unpol_inelastic_loop += output.sigma_unpol_inelastic_1st_hadr_interf;
+			errors.sigma_unpol_inelastic_loop = sqrt(pow(errors.sigma_unpol_inelastic_1st,2.) + 
+                                        pow(errors.sigma_unpol_inelastic_1st_hadr_interf,2.));
 		}
 		std::cout <<"completed\n";
 	}
 
-	if (param.flag[param.hadr_corr] == 2 || param.flag[param.hadr_corr] == 3) {
-
-		std::cout << "Numerical integration for the purely hadronic part of one hard-photon unpolarized cross-section ... ";
-
+	if (param.flag[param.brems_hadr] == 2 || param.flag[param.brems_hadr] == 3) {
+		std::cout << "Integration for purely hadronic one hard-photon unpolarized cross section ... ";
 		if (param.flag[param.int_method] == 0) {
-
 			llVegas(CP.NDIM_brems_1st, CP.NCOMP, integrands.cuba_integrand_brems_1st_hadr,
 					USERDATA, CP.NVEC, CP.EPSREL, CP.EPSABS, CP.flags, CP.SEED,
 					CP.MINEVAL, 1e7, CP.NSTART, CP.NINCREASE, CP.NBATCH,
 					CP.GRIDNO_brems_hadr, CP.STATEFILE, CP.SPIN,
 					&CP.neval, &CP.fail, integral, error, prob);
-
 			llVegas(CP.NDIM_brems_1st, CP.NCOMP, integrands.cuba_integrand_brems_1st_hadr,
 					USERDATA, CP.NVEC, CP.EPSREL, CP.EPSABS, CP.flags_brems, CP.SEED,
 					CP.MINEVAL, CP.MAXEVAL_1st, CP.NSTART, CP.NINCREASE, CP.NBATCH,
 					CP.GRIDNO_brems_hadr, CP.STATEFILE, CP.SPIN,
 					&CP.neval, &CP.fail, integral, error, prob);
-
 		}
-
 		if (param.flag[param.int_method] == 1) {
-
 			llSuave(CP.NDIM_brems_1st, CP.NCOMP, integrands.cuba_integrand_brems_1st_hadr,
 					USERDATA, CP.NVEC, CP.EPSREL, CP.EPSABS, CP.flags_brems | 4, CP.SEED,
 					CP.MINEVAL, CP.MAXEVAL_1st, CP.NNEW, CP.NMIN, CP.FLATNESS,
 					CP.STATEFILE, CP.SPIN,
 					&CP.nregions, &CP.neval, &CP.fail, integral, error, prob);
-
 		}
 		output.sigma_unpol_inelastic_1st_hadr = integral[CP.comp]*nb;
 		errors.sigma_unpol_inelastic_1st_hadr = error[CP.comp]*nb;
-
 		if (param.flag[param.order] == 0 || param.flag[param.order] == 1) {
 			output.sigma_unpol_inelastic_1st += output.sigma_unpol_inelastic_1st_hadr;
-			errors.sigma_unpol_inelastic_1st = sqrt(pow(errors.sigma_unpol_inelastic_1st,2.)
-					+ pow(errors.sigma_unpol_inelastic_1st_hadr,2.));
-			output.sigma_unpol_1st = output.sigma_unpol_inelastic_1st + output.sigma_unpol_elastic_1st;
-			errors.sigma_unpol_1st = sqrt(pow(errors.sigma_unpol_inelastic_1st,2.)
-					+ pow(errors.sigma_unpol_elastic_1st,2.));
+			errors.sigma_unpol_inelastic_1st = sqrt(pow(errors.sigma_unpol_inelastic_1st,2.) + 
+                                                pow(errors.sigma_unpol_inelastic_1st_hadr,2.));
+			output.sigma_unpol_1st = output.sigma_unpol_inelastic_1st + 
+                                     output.sigma_unpol_elastic_1st;
+			errors.sigma_unpol_1st = sqrt(pow(errors.sigma_unpol_inelastic_1st,2.) + 
+                                          pow(errors.sigma_unpol_elastic_1st,2.));
 		}
-
 		if (param.flag[param.order] == 2) {
 			output.sigma_unpol_inelastic_loop += output.sigma_unpol_inelastic_1st_hadr;
-			errors.sigma_unpol_inelastic_loop = sqrt(pow(errors.sigma_unpol_inelastic_1st,2.)
-					+ pow(errors.sigma_unpol_inelastic_1st_hadr,2.));
+			errors.sigma_unpol_inelastic_loop = sqrt(pow(errors.sigma_unpol_inelastic_1st,2.) + 
+                                                pow(errors.sigma_unpol_inelastic_1st_hadr,2.));
 		}
 		std::cout <<"completed\n";
 	}
+// End section for hadronic corrections 
 
+
+// One hard photon radiation for polarized cross section 
+// for second order including loop+soft-photon correction
+            if (param.flag[param.asymmetry] == 1 && 
+                (param.flag[param.brems] == 1 || 
+                 param.flag[param.brems] == 2)) {
+                std::cout << "Integration for one hard photon polarized cross section ... ";
+                if (param.flag[param.int_method] == 0) {
+                    llVegas(CP.NDIM_brems_1st, CP.NCOMP, 
+                            integrands.cuba_integrand_interf_brems_1st,
+                            USERDATA, CP.NVEC, CP.EPSREL, CP.EPSABS, CP.flags, CP.SEED,
+                            CP.MINEVAL, 1e7, CP.NSTART, CP.NINCREASE, CP.NBATCH,
+                            CP.GRIDNO_brems_interf, CP.STATEFILE, CP.SPIN,
+                            &CP.neval, &CP.fail, integral, error, prob);
+                    llVegas(CP.NDIM_brems_1st, CP.NCOMP, 
+                            integrands.cuba_integrand_interf_brems_1st,
+                            USERDATA, CP.NVEC, CP.EPSREL, CP.EPSABS, CP.flags, CP.SEED,
+                            CP.MINEVAL, CP.MAXEVAL_1st, CP.NSTART, CP.NINCREASE, CP.NBATCH,
+                            CP.GRIDNO_brems_interf, CP.STATEFILE, CP.SPIN,
+                            &CP.neval, &CP.fail, integral, error, prob);
+                }
+                if (param.flag[param.int_method] == 1) {
+                    llSuave(CP.NDIM_brems_1st, CP.NCOMP, 
+                            integrands.cuba_integrand_interf_brems_1st,
+                            USERDATA, CP.NVEC, CP.EPSREL, CP.EPSABS, CP.flags_brems | 4, CP.SEED,
+                            CP.MINEVAL, CP.MAXEVAL_1st, CP.NNEW, CP.NMIN, CP.FLATNESS,
+                            CP.STATEFILE, CP.SPIN,
+                            &CP.nregions, &CP.neval, &CP.fail, integral, error, prob);
+                }
+                if (param.flag[param.int_method] == 2) {
+                    llCuhre(CP.NDIM_brems_1st, CP.NCOMP, 
+                            integrands.cuba_integrand_interf_brems_1st,
+                            USERDATA, CP.NVEC, CP.EPSREL, CP.EPSABS, CP.flags_brems | 4,
+                            CP.MINEVAL, CP.MAXEVAL_1st, 9,
+                            CP.STATEFILE, CP.SPIN,
+                            &CP.nregions, &CP.neval, &CP.fail, integral, error, prob);
+                }
+                if (param.flag[param.order] == 1 || param.flag[param.order] == 2) {
+                    output.sigma_pol_inelastic_1st = param.P*integral[CP.comp]*nb;
+                    errors.sigma_pol_inelastic_1st = param.P*error[CP.comp]*nb;
+                    output.sigma_pol_1st = output.sigma_pol_inelastic_1st + 
+                                           output.sigma_pol_elastic_1st;
+                    errors.sigma_pol_1st = errors.sigma_pol_inelastic_1st + 
+                                           errors.sigma_pol_elastic_1st;
+                    output.asymm_1st = output.sigma_pol_1st / output.sigma_unpol_1st;
+                    errors.asymm_1st = abs(output.asymm_1st) * 
+                                       sqrt(pow(errors.sigma_pol_1st / output.sigma_pol_1st, 2.) + 
+                                            pow(errors.sigma_unpol_1st / output.sigma_unpol_1st, 2.));
+                    output.rel_asymm_1st = - 100.*(output.asymm_1st - output.asymm_born) / 
+                                                  output.asymm_born;
+                    output.sigma_1st = output.sigma_pol_1st + output.sigma_unpol_1st;
+                    errors.sigma_1st = sqrt(pow(output.sigma_pol_1st,2.) + 
+                                            pow(output.sigma_unpol_1st,2.));
+                }
+                if (param.flag[param.order] == 2) {
+                    output.sigma_pol_inelastic_loop = param.P*integral[CP.comp]*nb;
+                    errors.sigma_pol_inelastic_loop = param.P*error[CP.comp]*nb;
+                }
+                std::cout << "completed\n";
+                if (param.flag[param.order] == 2 && param.flag[param.brems_add] == 1) {
+                    std::cout << "Integration for one hard + one soft photon finite contribution ... ";
+                    llSuave(CP.NDIM_brems_2nd, CP.NCOMP, 
+                            integrands.cuba_integrand_brems_2nd_pol_add,
+                            USERDATA, CP.NVEC, CP.EPSREL, CP.EPSABS, CP.flags_brems | 4, CP.SEED,
+                            CP.MINEVAL, CP.MAXEVAL_2nd_add, CP.NNEW, CP.NMIN, CP.FLATNESS,
+                            CP.STATEFILE, CP.SPIN,
+                            &CP.nregions, &CP.neval, &CP.fail, integral, error, prob);
+                    output.sigma_pol_2nd_add = param.P*integral[CP.comp]*nb;
+                    errors.sigma_pol_2nd_add = param.P*error[CP.comp]*nb;
+                    output.sigma_pol_inelastic_loop += output.sigma_pol_2nd_add;
+                    errors.sigma_pol_inelastic_loop = sqrt(pow(errors.sigma_pol_2nd_add,2.) + 
+                                                           pow(errors.sigma_pol_inelastic_loop,2.));
+                    std::cout <<"completed\n";
+                }
+            }
+// End section for one-photon bremsstrahlung for polarized cross section
+
+
+// Second order corrections
+        if (param.flag[param.brems] >= 2 || param.flag[param.brems_add] >= 1) {
+            std::cout <<"Start integration for 2nd order bremsstrahlung\n";
+            std::cout <<"***** This may take a while . . . \n";
+        }
+        
+// Second order correction: finite soft*hard terms
 		if (param.flag[param.order] == 2 && param.flag[param.brems_add] == 1) {
-
-			std::cout << "Numerical integration for one hard-photon and one soft-photon finite contribution ... ";
-
+			std::cout << "Integration for one hard + one soft photon finite contribution ... ";
 			double sigma_add_l1k1, sigma_add_l1k2, sigma_add_l2k1, sigma_add_l2k2;
-			double error_sigma_add_l1k1, error_sigma_add_l1k2, error_sigma_add_l2k1, error_sigma_add_l2k2;
-//
+			double error_sigma_add_l1k1, error_sigma_add_l1k2, error_sigma_add_l2k1, 
+                   error_sigma_add_l2k2;
+// Vegas integration disabled. Always use Suave, independent of input for 
+// integration method. 
 //			if (param.flag[param.int_method] == 0) {
 //				llVegas(CP.NDIM_brems_2nd, CP.NCOMP, integrands.cuba_integrand_brems_2nd_add_l1k1,
 //						USERDATA, CP.NVEC, CP.EPSREL, CP.EPSABS, CP.flags, CP.SEED,
@@ -512,1264 +572,590 @@ int PES::initialization(){
 //				sigma_add_l2k2 = integral[CP.comp]*nb;
 //				error_sigma_add_l2k2 = error[CP.comp]*nb;
 //			}
-
 //			if (param.flag[param.int_method] == 1) {
 				llSuave(CP.NDIM_brems_2nd, CP.NCOMP, integrands.cuba_integrand_brems_2nd_add_l1k1,
 						USERDATA, CP.NVEC, CP.EPSREL, CP.EPSABS, CP.flags_brems | 4, CP.SEED,
 						CP.MINEVAL, CP.MAXEVAL_2nd_add, CP.NNEW, CP.NMIN, CP.FLATNESS,
 						CP.STATEFILE, CP.SPIN,
 						&CP.nregions, &CP.neval, &CP.fail, integral, error, prob);
-
 				sigma_add_l1k1 = integral[CP.comp]*nb;
 				error_sigma_add_l1k1 = error[CP.comp]*nb;
-
 				llSuave(CP.NDIM_brems_2nd, CP.NCOMP, integrands.cuba_integrand_brems_2nd_add_l2k1,
 						USERDATA, CP.NVEC, CP.EPSREL, CP.EPSABS, CP.flags_brems | 4, CP.SEED,
 						CP.MINEVAL, CP.MAXEVAL_2nd_add, CP.NNEW, CP.NMIN, CP.FLATNESS,
 						CP.STATEFILE, CP.SPIN,
 						&CP.nregions, &CP.neval, &CP.fail, integral, error, prob);
-
 				sigma_add_l2k1 = integral[CP.comp]*nb;
 				error_sigma_add_l2k1 = error[CP.comp]*nb;
-
 				llSuave(CP.NDIM_brems_2nd, CP.NCOMP, integrands.cuba_integrand_brems_2nd_add_l1k2,
 						USERDATA, CP.NVEC, CP.EPSREL, CP.EPSABS, CP.flags_brems | 4, CP.SEED,
 						CP.MINEVAL, CP.MAXEVAL_2nd_add, CP.NNEW, CP.NMIN, CP.FLATNESS,
 						CP.STATEFILE, CP.SPIN,
 						&CP.nregions, &CP.neval, &CP.fail, integral, error, prob);
-
 				sigma_add_l1k2 = integral[CP.comp]*nb;
 				error_sigma_add_l1k2 = error[CP.comp]*nb;
-
 				llSuave(CP.NDIM_brems_2nd, CP.NCOMP, integrands.cuba_integrand_brems_2nd_add_l2k2,
 						USERDATA, CP.NVEC, CP.EPSREL, CP.EPSABS, CP.flags_brems | 4, CP.SEED,
 						CP.MINEVAL, CP.MAXEVAL_2nd_add, CP.NNEW, CP.NMIN, CP.FLATNESS,
 						CP.STATEFILE, CP.SPIN,
 						&CP.nregions, &CP.neval, &CP.fail, integral, error, prob);
-
 				sigma_add_l2k2 = integral[CP.comp]*nb;
 				error_sigma_add_l2k2 = error[CP.comp]*nb;
 //			}
-
 			double sigma_add = sigma_add_l1k1 + sigma_add_l2k1 + sigma_add_l1k2 + sigma_add_l2k2;
-			double error_sigma_add = sqrt(pow(error_sigma_add_l1k1,2.) + pow(error_sigma_add_l2k1,2.)
-					+ pow(error_sigma_add_l1k2,2.) + pow(error_sigma_add_l2k2,2.));
-
+			double error_sigma_add = sqrt(pow(error_sigma_add_l1k1,2.) + 
+                                          pow(error_sigma_add_l2k1,2.) + 
+                                          pow(error_sigma_add_l1k2,2.) + 
+                                          pow(error_sigma_add_l2k2,2.));
 			output.sigma_unpol_2nd_add = sigma_add;
 			errors.sigma_unpol_2nd_add = error_sigma_add;
 			output.sigma_unpol_inelastic_loop += output.sigma_unpol_2nd_add;
 			errors.sigma_unpol_inelastic_loop = sqrt(pow(errors.sigma_unpol_2nd_add,2.)
 													+ pow(errors.sigma_unpol_inelastic_loop,2.));
-
 			std::cout <<"completed\n";
-
 		}
+// End section for 'additional' finite terms
 
-		if (param.flag[param.order] == 2 && param.flag[param.brems] == 1) {
-			output.sigma_unpol_2nd = output.sigma_unpol_elastic_2nd
-					+ output.sigma_unpol_inelastic_loop;
-			errors.sigma_unpol_2nd = sqrt(pow(errors.sigma_unpol_elastic_2nd,2.)
-					+ pow(errors.sigma_unpol_inelastic_loop,2.));
+
+//        
+    if (param.flag[param.order] == 2 && param.flag[param.brems] == 1) {
+        std::cout << "***** WARNING: ***** \n"
+                  << "***** 2nd order loop is combined with 1st order bremsstrahlung \n" 
+                  << "***** Result is incomplete! \n\n"; 
+        output.sigma_unpol_2nd = output.sigma_unpol_elastic_2nd + 
+                                 output.sigma_unpol_inelastic_loop;
+        errors.sigma_unpol_2nd = sqrt(pow(errors.sigma_unpol_elastic_2nd,2.) + 
+                                      pow(errors.sigma_unpol_inelastic_loop,2.));
 		}
+//
 
+
+// 2nd order bremsstrahlung: two hard photons
 	if (param.flag[param.brems] == 2 || param.flag[param.brems] == 3) {
-
-		std::cout << "Numerical integration for two hard-photons unpolarized cross-section ... ";
-
+		std::cout << "Integration for two-hard-photon unpolarized cross section ... ";
 		if (param.flag[param.int_method] == 0) {
-
 			llVegas(CP.NDIM_brems_2nd, CP.NCOMP, integrands.cuba_integrand_brems_2nd_l1k1,
 					USERDATA, CP.NVEC, CP.EPSREL, CP.EPSABS, CP.flags, CP.SEED,
 					CP.MINEVAL, 1e8, CP.NSTART, CP.NINCREASE, CP.NBATCH,
 					CP.GRIDNO_brems_2nd_l1k1, CP.STATEFILE, CP.SPIN,
 					&CP.neval, &CP.fail, integral, error, prob);
-
 			llVegas(CP.NDIM_brems_2nd, CP.NCOMP, integrands.cuba_integrand_brems_2nd_l1k1,
 					USERDATA, CP.NVEC, CP.EPSREL, CP.EPSABS, CP.flags_brems, CP.SEED,
 					CP.MINEVAL, CP.MAXEVAL_2nd, CP.NSTART, CP.NINCREASE, CP.NBATCH,
 					CP.GRIDNO_brems_2nd_l1k1, CP.STATEFILE, CP.SPIN,
 					&CP.neval, &CP.fail, integral, error, prob);
-
 			sigma_hp_2nd_l1k1 = integral[CP.comp]*nb;
 			sigma_hp_2nd_l1k1_error = error[CP.comp]*nb;
-
 			llVegas(CP.NDIM_brems_2nd, CP.NCOMP, integrands.cuba_integrand_brems_2nd_l1k2,
 					USERDATA, CP.NVEC, CP.EPSREL, CP.EPSABS, CP.flags, CP.SEED,
 					CP.MINEVAL, 1e8, CP.NSTART, CP.NINCREASE, CP.NBATCH,
 					CP.GRIDNO_brems_2nd_l1k2, CP.STATEFILE, CP.SPIN,
 					&CP.neval, &CP.fail, integral, error, prob);
-
 			llVegas(CP.NDIM_brems_2nd, CP.NCOMP, integrands.cuba_integrand_brems_2nd_l1k2,
 					USERDATA, CP.NVEC, CP.EPSREL, CP.EPSABS, CP.flags_brems, CP.SEED,
 					CP.MINEVAL, CP.MAXEVAL_2nd, CP.NSTART, CP.NINCREASE, CP.NBATCH,
 					CP.GRIDNO_brems_2nd_l1k2, CP.STATEFILE, CP.SPIN,
 					&CP.neval, &CP.fail, integral, error, prob);
-
 			sigma_hp_2nd_l1k2 = integral[CP.comp]*nb;
 			sigma_hp_2nd_l1k2_error = error[CP.comp]*nb;
-
 			llVegas(CP.NDIM_brems_2nd, CP.NCOMP, integrands.cuba_integrand_brems_2nd_l2k1,
 					USERDATA, CP.NVEC, CP.EPSREL, CP.EPSABS, CP.flags, CP.SEED,
 					CP.MINEVAL, 1e8, CP.NSTART, CP.NINCREASE, CP.NBATCH,
 					CP.GRIDNO_brems_2nd_l2k1, CP.STATEFILE, CP.SPIN,
 					&CP.neval, &CP.fail, integral, error, prob);
-
 			llVegas(CP.NDIM_brems_2nd, CP.NCOMP, integrands.cuba_integrand_brems_2nd_l2k1,
 					USERDATA, CP.NVEC, CP.EPSREL, CP.EPSABS, CP.flags_brems, CP.SEED,
 					CP.MINEVAL, CP.MAXEVAL_2nd, CP.NSTART, CP.NINCREASE, CP.NBATCH,
 					CP.GRIDNO_brems_2nd_l2k1, CP.STATEFILE, CP.SPIN,
 					&CP.neval, &CP.fail, integral, error, prob);
-
 			sigma_hp_2nd_l2k1 = integral[CP.comp]*nb;
 			sigma_hp_2nd_l2k1_error = error[CP.comp]*nb;
-
 			llVegas(CP.NDIM_brems_2nd, CP.NCOMP, integrands.cuba_integrand_brems_2nd_l2k2,
 					USERDATA, CP.NVEC, CP.EPSREL, CP.EPSABS, CP.flags, CP.SEED,
 					CP.MINEVAL, 1e8, CP.NSTART, CP.NINCREASE, CP.NBATCH,
 					CP.GRIDNO_brems_2nd_l2k2, CP.STATEFILE, CP.SPIN,
 					&CP.neval, &CP.fail, integral, error, prob);
-
 			llVegas(CP.NDIM_brems_2nd, CP.NCOMP, integrands.cuba_integrand_brems_2nd_l2k2,
 					USERDATA, CP.NVEC, CP.EPSREL, CP.EPSABS, CP.flags_brems, CP.SEED,
 					CP.MINEVAL, CP.MAXEVAL_2nd, CP.NSTART, CP.NINCREASE, CP.NBATCH,
 					CP.GRIDNO_brems_2nd_l2k2, CP.STATEFILE, CP.SPIN,
 					&CP.neval, &CP.fail, integral, error, prob);
-
 			sigma_hp_2nd_l2k2 = integral[CP.comp]*nb;
 			sigma_hp_2nd_l2k2_error = error[CP.comp]*nb;
 		}
-
 		if (param.flag[param.int_method] == 1) {
-
 			llSuave(CP.NDIM_brems_2nd, CP.NCOMP, integrands.cuba_integrand_brems_2nd_l1k1,
 					USERDATA, CP.NVEC, CP.EPSREL, CP.EPSABS, CP.flags_brems | 4, CP.SEED,
 					CP.MINEVAL, CP.MAXEVAL_2nd, CP.NNEW, CP.NMIN, CP.FLATNESS,
 					CP.STATEFILE, CP.SPIN,
 					&CP.nregions, &CP.neval, &CP.fail, integral, error, prob);
-
 			sigma_hp_2nd_l1k1 = integral[CP.comp]*nb;
 			sigma_hp_2nd_l1k1_error = error[CP.comp]*nb;
-
 			llSuave(CP.NDIM_brems_2nd, CP.NCOMP, integrands.cuba_integrand_brems_2nd_l1k2,
 					USERDATA, CP.NVEC, CP.EPSREL, CP.EPSABS, CP.flags_brems | 4, CP.SEED,
 					CP.MINEVAL, CP.MAXEVAL_2nd, CP.NNEW, CP.NMIN, CP.FLATNESS,
 					CP.STATEFILE, CP.SPIN,
 					&CP.nregions, &CP.neval, &CP.fail, integral, error, prob);
-
 			sigma_hp_2nd_l1k2 = integral[CP.comp]*nb;
 			sigma_hp_2nd_l1k2_error = error[CP.comp]*nb;
-
 			llSuave(CP.NDIM_brems_2nd, CP.NCOMP, integrands.cuba_integrand_brems_2nd_l2k1,
 					USERDATA, CP.NVEC, CP.EPSREL, CP.EPSABS, CP.flags_brems | 4, CP.SEED,
 					CP.MINEVAL, CP.MAXEVAL_2nd, CP.NNEW, CP.NMIN, CP.FLATNESS,
 					CP.STATEFILE, CP.SPIN,
 					&CP.nregions, &CP.neval, &CP.fail, integral, error, prob);
-
 			sigma_hp_2nd_l2k1 = integral[CP.comp]*nb;
 			sigma_hp_2nd_l2k1_error = error[CP.comp]*nb;
-
 			llSuave(CP.NDIM_brems_2nd, CP.NCOMP, integrands.cuba_integrand_brems_2nd_l2k2,
 					USERDATA, CP.NVEC, CP.EPSREL, CP.EPSABS, CP.flags_brems | 4, CP.SEED,
 					CP.MINEVAL, CP.MAXEVAL_2nd, CP.NNEW, CP.NMIN, CP.FLATNESS,
 					CP.STATEFILE, CP.SPIN,
 					&CP.nregions, &CP.neval, &CP.fail, integral, error, prob);
-
 			sigma_hp_2nd_l2k2 = integral[CP.comp]*nb;
 			sigma_hp_2nd_l2k2_error = error[CP.comp]*nb;
 		}
-
 		if (param.flag[param.int_method] == 2) {
-
 			llCuhre(CP.NDIM_brems_2nd, CP.NCOMP, integrands.cuba_integrand_brems_2nd_l1k1,
 					USERDATA, CP.NVEC, CP.EPSREL, CP.EPSABS, CP.flags_brems | 4,
 					CP.MINEVAL, CP.MAXEVAL_2nd, CP.KEY,
 					CP.STATEFILE, CP.SPIN,
 					&CP.nregions, &CP.neval, &CP.fail, integral, error, prob);
-
 			sigma_hp_2nd_l1k1 = integral[CP.comp]*nb;
 			sigma_hp_2nd_l1k1_error = error[CP.comp]*nb;
-
 			llCuhre(CP.NDIM_brems_2nd, CP.NCOMP, integrands.cuba_integrand_brems_2nd_l1k2,
 					USERDATA, CP.NVEC, CP.EPSREL, CP.EPSABS, CP.flags_brems | 4,
 					CP.MINEVAL, CP.MAXEVAL_2nd, CP.KEY,
 					CP.STATEFILE, CP.SPIN,
 					&CP.nregions, &CP.neval, &CP.fail, integral, error, prob);
-
 			sigma_hp_2nd_l1k2 = integral[CP.comp]*nb;
 			sigma_hp_2nd_l1k2_error = error[CP.comp]*nb;
-
 			llCuhre(CP.NDIM_brems_2nd, CP.NCOMP, integrands.cuba_integrand_brems_2nd_l2k1,
 					USERDATA, CP.NVEC, CP.EPSREL, CP.EPSABS, CP.flags_brems | 4,
 					CP.MINEVAL, CP.MAXEVAL_2nd, CP.KEY,
 					CP.STATEFILE, CP.SPIN,
 					&CP.nregions, &CP.neval, &CP.fail, integral, error, prob);
-
 			sigma_hp_2nd_l2k1 = integral[CP.comp]*nb;
 			sigma_hp_2nd_l2k1_error = error[CP.comp]*nb;
-
 			llCuhre(CP.NDIM_brems_2nd, CP.NCOMP, integrands.cuba_integrand_brems_2nd_l2k2,
 					USERDATA, CP.NVEC, CP.EPSREL, CP.EPSABS, CP.flags_brems | 4,
 					CP.MINEVAL, CP.MAXEVAL_2nd, CP.KEY,
 					CP.STATEFILE, CP.SPIN,
 					&CP.nregions, &CP.neval, &CP.fail, integral, error, prob);
-
 			sigma_hp_2nd_l2k2 = integral[CP.comp]*nb;
 			sigma_hp_2nd_l2k2_error = error[CP.comp]*nb;
 		}
-
-//		std::cout << sigma_hp_2nd_l1k1 << " +- " << sigma_hp_2nd_l1k1_error <<"\n";
-//		std::cout << sigma_hp_2nd_l1k2 << " +- " << sigma_hp_2nd_l1k2_error <<"\n";
-//		std::cout << sigma_hp_2nd_l2k1 << " +- " << sigma_hp_2nd_l2k1_error <<"\n";
-//		std::cout << sigma_hp_2nd_l2k2 << " +- " << sigma_hp_2nd_l2k2_error <<"\n";
-
-		output.sigma_unpol_inelastic_2nd = sigma_hp_2nd_l1k1 + sigma_hp_2nd_l1k2 + sigma_hp_2nd_l2k1 + sigma_hp_2nd_l2k2;
-		errors.sigma_unpol_inelastic_2nd = sqrt(pow(sigma_hp_2nd_l1k1_error,2.) + pow(sigma_hp_2nd_l1k2_error,2.)
-											+ pow(sigma_hp_2nd_l2k1_error,2.) + pow(sigma_hp_2nd_l2k2_error,2.));
-
+		output.sigma_unpol_inelastic_2nd = sigma_hp_2nd_l1k1 + 
+                                           sigma_hp_2nd_l1k2 + 
+                                           sigma_hp_2nd_l2k1 + 
+                                           sigma_hp_2nd_l2k2;
+		errors.sigma_unpol_inelastic_2nd = sqrt(pow(sigma_hp_2nd_l1k1_error,2.) + 
+                                                pow(sigma_hp_2nd_l1k2_error,2.) + 
+                                                pow(sigma_hp_2nd_l2k1_error,2.) + 
+                                                pow(sigma_hp_2nd_l2k2_error,2.));
 		if (param.flag[param.order] == 2) {
-			output.sigma_unpol_2nd = output.sigma_unpol_elastic_2nd
-					+ output.sigma_unpol_inelastic_loop + output.sigma_unpol_inelastic_2nd;
-			errors.sigma_unpol_2nd = sqrt(pow(errors.sigma_unpol_elastic_2nd,2.)
-					+ pow(errors.sigma_unpol_inelastic_loop,2.) + pow(errors.sigma_unpol_inelastic_2nd,2.));
+			output.sigma_unpol_2nd = output.sigma_unpol_elastic_2nd + 
+                                     output.sigma_unpol_inelastic_loop + 
+                                     output.sigma_unpol_inelastic_2nd;
+			errors.sigma_unpol_2nd = sqrt(pow(errors.sigma_unpol_elastic_2nd,2.) + 
+                                          pow(errors.sigma_unpol_inelastic_loop,2.) + 
+                                          pow(errors.sigma_unpol_inelastic_2nd,2.));
 		}
 		std::cout <<"completed\n";
 	}
+// End section for 2-hard-photon bremsstrahlung 
 
+
+// Hard radiation for differential cross sections
+// brems=4: 1st order 2-fold differential in theta_l and theta_gamma 
 	if (param.flag[param.brems] == 4) {
-
 		if (param.flag[param.int_method] == 0) {
-
 			if (param.flag[param.PS] == 0) {
-				llVegas(CP.NDIM_brems_1st_2diff, CP.NCOMP, integrands.cuba_integrand_brems_1st_2diff_v1,
+				llVegas(CP.NDIM_brems_1st_2diff, CP.NCOMP, 
+                        integrands.cuba_integrand_brems_1st_2diff_v1,
 						USERDATA, CP.NVEC, CP.EPSREL, CP.EPSABS, CP.flags, CP.SEED,
 						CP.MINEVAL, 1e7, CP.NSTART, CP.NINCREASE, CP.NBATCH,
 						CP.GRIDNO, CP.STATEFILE, CP.SPIN,
 						&CP.neval, &CP.fail, integral, error, prob);
-
-				llVegas(CP.NDIM_brems_1st_2diff, CP.NCOMP, integrands.cuba_integrand_brems_1st_2diff_v1,
+				llVegas(CP.NDIM_brems_1st_2diff, CP.NCOMP, 
+                        integrands.cuba_integrand_brems_1st_2diff_v1,
 						USERDATA, CP.NVEC, CP.EPSREL, CP.EPSABS, CP.flags, CP.SEED,
 						CP.MINEVAL, CP.MAXEVAL_1st, CP.NSTART, CP.NINCREASE, CP.NBATCH,
 						CP.GRIDNO, CP.STATEFILE, CP.SPIN,
 						&CP.neval, &CP.fail, integral, error, prob);
 			}
-
 			if (param.flag[param.PS] == 1) {
-				llVegas(CP.NDIM_brems_1st_2diff, CP.NCOMP, integrands.cuba_integrand_brems_1st_ps2_2diff,
+				llVegas(CP.NDIM_brems_1st_2diff, CP.NCOMP, 
+                        integrands.cuba_integrand_brems_1st_ps2_2diff,
 						USERDATA, CP.NVEC, CP.EPSREL, CP.EPSABS, CP.flags, CP.SEED,
 						CP.MINEVAL, 1e7, CP.NSTART, CP.NINCREASE, CP.NBATCH,
 						CP.GRIDNO, CP.STATEFILE, CP.SPIN,
 						&CP.neval, &CP.fail, integral, error, prob);
-
-				llVegas(CP.NDIM_brems_1st_2diff, CP.NCOMP, integrands.cuba_integrand_brems_1st_ps2_2diff,
+				llVegas(CP.NDIM_brems_1st_2diff, CP.NCOMP, 
+                        integrands.cuba_integrand_brems_1st_ps2_2diff,
 						USERDATA, CP.NVEC, CP.EPSREL, CP.EPSABS, CP.flags, CP.SEED,
 						CP.MINEVAL, CP.MAXEVAL_1st, CP.NSTART, CP.NINCREASE, CP.NBATCH,
 						CP.GRIDNO, CP.STATEFILE, CP.SPIN,
 						&CP.neval, &CP.fail, integral, error, prob);
 			}
 		}
-
 		if (param.flag[param.int_method] == 1) {
-
 			if (param.flag[param.PS] == 0) {
-				llSuave(CP.NDIM_brems_1st_2diff, CP.NCOMP, integrands.cuba_integrand_brems_1st_2diff_v1,
+				llSuave(CP.NDIM_brems_1st_2diff, CP.NCOMP, 
+                        integrands.cuba_integrand_brems_1st_2diff_v1,
 						USERDATA, CP.NVEC, CP.EPSREL, CP.EPSABS, CP.flags_brems | 4, CP.SEED,
 						CP.MINEVAL, CP.MAXEVAL_1st, CP.NNEW, CP.NMIN, CP.FLATNESS,
 						CP.STATEFILE, CP.SPIN,
 						&CP.nregions, &CP.neval, &CP.fail, integral, error, prob);
 			}
-
 			if (param.flag[param.PS] == 1) {
-				llSuave(CP.NDIM_brems_1st_2diff, CP.NCOMP, integrands.cuba_integrand_brems_1st_ps2_2diff,
+				llSuave(CP.NDIM_brems_1st_2diff, CP.NCOMP, 
+                        integrands.cuba_integrand_brems_1st_ps2_2diff,
 						USERDATA, CP.NVEC, CP.EPSREL, CP.EPSABS, CP.flags_brems | 4, CP.SEED,
 						CP.MINEVAL, CP.MAXEVAL_1st, CP.NNEW, CP.NMIN, CP.FLATNESS,
 						CP.STATEFILE, CP.SPIN,
 						&CP.nregions, &CP.neval, &CP.fail, integral, error, prob);
 			}
 		}
-
 		if (param.flag[param.int_method] == 2) {
-
 			if (param.flag[param.PS] == 0) {
-				llCuhre(CP.NDIM_brems_1st_2diff, CP.NCOMP, integrands.cuba_integrand_brems_1st_2diff_v1,
+				llCuhre(CP.NDIM_brems_1st_2diff, CP.NCOMP, 
+                        integrands.cuba_integrand_brems_1st_2diff_v1,
 						USERDATA, CP.NVEC, CP.EPSREL, CP.EPSABS, CP.flags_brems | 4,
 						CP.MINEVAL, CP.MAXEVAL_1st, CP.KEY,
 						CP.STATEFILE, CP.SPIN,
 						&CP.nregions, &CP.neval, &CP.fail, integral, error, prob);
 			}
 			if (param.flag[param.PS] == 1) {
-				llCuhre(CP.NDIM_brems_1st_2diff, CP.NCOMP, integrands.cuba_integrand_brems_1st_ps2_2diff,
+				llCuhre(CP.NDIM_brems_1st_2diff, CP.NCOMP, 
+                        integrands.cuba_integrand_brems_1st_ps2_2diff,
 						USERDATA, CP.NVEC, CP.EPSREL, CP.EPSABS, CP.flags_brems | 4,
 						CP.MINEVAL, CP.MAXEVAL_1st, CP.KEY,
 						CP.STATEFILE, CP.SPIN,
 						&CP.nregions, &CP.neval, &CP.fail, integral, error, prob);
 			}
 		}
-
 		if (param.flag[param.order] == 1) {
 			output.sigma_unpol_inelastic_1st = integral[CP.comp]*nb;
 			errors.sigma_unpol_inelastic_1st = error[CP.comp]*nb;
 		}
-//
 		if (param.flag[param.order] == 2) {
 			output.sigma_unpol_inelastic_loop = integral[CP.comp]*nb;
 			errors.sigma_unpol_inelastic_loop = error[CP.comp]*nb;
 		}
 	}
+// End section bremsstrahlung type = 4
 
+// brems=5: 2nd order 2-fold differential in theta_l and theta_gamma 
 	if (param.flag[param.brems] == 5) {
-
 		if (param.flag[param.int_method] == 0) {
-
-			llVegas(CP.NDIM_brems_2nd_2diff, CP.NCOMP, integrands.cuba_integrand_brems_2nd_l1k1_2diff,
+			llVegas(CP.NDIM_brems_2nd_2diff, CP.NCOMP, 
+                    integrands.cuba_integrand_brems_2nd_l1k1_2diff,
 					USERDATA, CP.NVEC, CP.EPSREL, CP.EPSABS, CP.flags, CP.SEED,
 					CP.MINEVAL, 1e8, CP.NSTART, CP.NINCREASE, CP.NBATCH,
 					CP.GRIDNO_brems_2nd_l1k1, CP.STATEFILE, CP.SPIN,
 					&CP.neval, &CP.fail, integral, error, prob);
-
-			llVegas(CP.NDIM_brems_2nd_2diff, CP.NCOMP, integrands.cuba_integrand_brems_2nd_l1k1_2diff,
+			llVegas(CP.NDIM_brems_2nd_2diff, CP.NCOMP, 
+                    integrands.cuba_integrand_brems_2nd_l1k1_2diff,
 					USERDATA, CP.NVEC, CP.EPSREL, CP.EPSABS, CP.flags_brems, CP.SEED,
 					CP.MINEVAL, CP.MAXEVAL_2nd, CP.NSTART, CP.NINCREASE, CP.NBATCH,
 					CP.GRIDNO_brems_2nd_l1k1, CP.STATEFILE, CP.SPIN,
 					&CP.neval, &CP.fail, integral, error, prob);
-
 			sigma_hp_2nd_l1k1 = integral[CP.comp]*nb;
 			sigma_hp_2nd_l1k1_error = error[CP.comp]*nb;
-
-			llVegas(CP.NDIM_brems_2nd_2diff, CP.NCOMP, integrands.cuba_integrand_brems_2nd_l1k2_2diff,
+			llVegas(CP.NDIM_brems_2nd_2diff, CP.NCOMP, 
+                    integrands.cuba_integrand_brems_2nd_l1k2_2diff,
 					USERDATA, CP.NVEC, CP.EPSREL, CP.EPSABS, CP.flags, CP.SEED,
 					CP.MINEVAL, 1e8, CP.NSTART, CP.NINCREASE, CP.NBATCH,
 					CP.GRIDNO_brems_2nd_l1k2, CP.STATEFILE, CP.SPIN,
 					&CP.neval, &CP.fail, integral, error, prob);
-
-			llVegas(CP.NDIM_brems_2nd_2diff, CP.NCOMP, integrands.cuba_integrand_brems_2nd_l1k2_2diff,
+			llVegas(CP.NDIM_brems_2nd_2diff, CP.NCOMP, 
+                    integrands.cuba_integrand_brems_2nd_l1k2_2diff,
 					USERDATA, CP.NVEC, CP.EPSREL, CP.EPSABS, CP.flags_brems, CP.SEED,
 					CP.MINEVAL, CP.MAXEVAL_2nd, CP.NSTART, CP.NINCREASE, CP.NBATCH,
 					CP.GRIDNO_brems_2nd_l1k2, CP.STATEFILE, CP.SPIN,
 					&CP.neval, &CP.fail, integral, error, prob);
-
 			sigma_hp_2nd_l1k2 = integral[CP.comp]*nb;
 			sigma_hp_2nd_l1k2_error = error[CP.comp]*nb;
-
-			llVegas(CP.NDIM_brems_2nd_2diff, CP.NCOMP, integrands.cuba_integrand_brems_2nd_l2k1_2diff,
+			llVegas(CP.NDIM_brems_2nd_2diff, CP.NCOMP, 
+                    integrands.cuba_integrand_brems_2nd_l2k1_2diff,
 					USERDATA, CP.NVEC, CP.EPSREL, CP.EPSABS, CP.flags, CP.SEED,
 					CP.MINEVAL, 1e8, CP.NSTART, CP.NINCREASE, CP.NBATCH,
 					CP.GRIDNO_brems_2nd_l2k1, CP.STATEFILE, CP.SPIN,
 					&CP.neval, &CP.fail, integral, error, prob);
-
-			llVegas(CP.NDIM_brems_2nd_2diff, CP.NCOMP, integrands.cuba_integrand_brems_2nd_l2k1_2diff,
+			llVegas(CP.NDIM_brems_2nd_2diff, CP.NCOMP, 
+                    integrands.cuba_integrand_brems_2nd_l2k1_2diff,
 					USERDATA, CP.NVEC, CP.EPSREL, CP.EPSABS, CP.flags_brems, CP.SEED,
 					CP.MINEVAL, CP.MAXEVAL_2nd, CP.NSTART, CP.NINCREASE, CP.NBATCH,
 					CP.GRIDNO_brems_2nd_l2k1, CP.STATEFILE, CP.SPIN,
 					&CP.neval, &CP.fail, integral, error, prob);
-
 			sigma_hp_2nd_l2k1 = integral[CP.comp]*nb;
 			sigma_hp_2nd_l2k1_error = error[CP.comp]*nb;
-
-			llVegas(CP.NDIM_brems_2nd_2diff, CP.NCOMP, integrands.cuba_integrand_brems_2nd_l2k2_2diff,
+			llVegas(CP.NDIM_brems_2nd_2diff, CP.NCOMP, 
+                    integrands.cuba_integrand_brems_2nd_l2k2_2diff,
 					USERDATA, CP.NVEC, CP.EPSREL, CP.EPSABS, CP.flags, CP.SEED,
 					CP.MINEVAL, 1e8, CP.NSTART, CP.NINCREASE, CP.NBATCH,
 					CP.GRIDNO_brems_2nd_l2k2, CP.STATEFILE, CP.SPIN,
 					&CP.neval, &CP.fail, integral, error, prob);
-
-			llVegas(CP.NDIM_brems_2nd_2diff, CP.NCOMP, integrands.cuba_integrand_brems_2nd_l2k2_2diff,
+			llVegas(CP.NDIM_brems_2nd_2diff, CP.NCOMP, 
+                    integrands.cuba_integrand_brems_2nd_l2k2_2diff,
 					USERDATA, CP.NVEC, CP.EPSREL, CP.EPSABS, CP.flags_brems, CP.SEED,
 					CP.MINEVAL, CP.MAXEVAL_2nd, CP.NSTART, CP.NINCREASE, CP.NBATCH,
 					CP.GRIDNO_brems_2nd_l2k2, CP.STATEFILE, CP.SPIN,
 					&CP.neval, &CP.fail, integral, error, prob);
-
 			sigma_hp_2nd_l2k2 = integral[CP.comp]*nb;
 			sigma_hp_2nd_l2k2_error = error[CP.comp]*nb;
 		}
-
 		if (param.flag[param.int_method] == 1) {
-
-			llSuave(CP.NDIM_brems_2nd_2diff, CP.NCOMP, integrands.cuba_integrand_brems_2nd_l1k1_2diff,
+			llSuave(CP.NDIM_brems_2nd_2diff, CP.NCOMP, 
+                    integrands.cuba_integrand_brems_2nd_l1k1_2diff,
 					USERDATA, CP.NVEC, CP.EPSREL, CP.EPSABS, CP.flags_brems | 4, CP.SEED,
 					CP.MINEVAL, CP.MAXEVAL_2nd, CP.NNEW, CP.NMIN, CP.FLATNESS,
 					CP.STATEFILE, CP.SPIN,
 					&CP.nregions, &CP.neval, &CP.fail, integral, error, prob);
-
 			sigma_hp_2nd_l1k1 = integral[CP.comp]*nb;
 			sigma_hp_2nd_l1k1_error = error[CP.comp]*nb;
-
-			llSuave(CP.NDIM_brems_2nd_2diff, CP.NCOMP, integrands.cuba_integrand_brems_2nd_l1k2_2diff,
+			llSuave(CP.NDIM_brems_2nd_2diff, CP.NCOMP, 
+                    integrands.cuba_integrand_brems_2nd_l1k2_2diff,
 					USERDATA, CP.NVEC, CP.EPSREL, CP.EPSABS, CP.flags_brems | 4, CP.SEED,
 					CP.MINEVAL, CP.MAXEVAL_2nd, CP.NNEW, CP.NMIN, CP.FLATNESS,
 					CP.STATEFILE, CP.SPIN,
 					&CP.nregions, &CP.neval, &CP.fail, integral, error, prob);
-
 			sigma_hp_2nd_l1k2 = integral[CP.comp]*nb;
 			sigma_hp_2nd_l1k2_error = error[CP.comp]*nb;
-
-			llSuave(CP.NDIM_brems_2nd_2diff, CP.NCOMP, integrands.cuba_integrand_brems_2nd_l2k1_2diff,
+			llSuave(CP.NDIM_brems_2nd_2diff, CP.NCOMP, 
+                    integrands.cuba_integrand_brems_2nd_l2k1_2diff,
 					USERDATA, CP.NVEC, CP.EPSREL, CP.EPSABS, CP.flags_brems | 4, CP.SEED,
 					CP.MINEVAL, CP.MAXEVAL_2nd, CP.NNEW, CP.NMIN, CP.FLATNESS,
 					CP.STATEFILE, CP.SPIN,
 					&CP.nregions, &CP.neval, &CP.fail, integral, error, prob);
-
 			sigma_hp_2nd_l2k1 = integral[CP.comp]*nb;
 			sigma_hp_2nd_l2k1_error = error[CP.comp]*nb;
-
-			llSuave(CP.NDIM_brems_2nd_2diff, CP.NCOMP, integrands.cuba_integrand_brems_2nd_l2k2_2diff,
+			llSuave(CP.NDIM_brems_2nd_2diff, CP.NCOMP, 
+                    integrands.cuba_integrand_brems_2nd_l2k2_2diff,
 					USERDATA, CP.NVEC, CP.EPSREL, CP.EPSABS, CP.flags_brems | 4, CP.SEED,
 					CP.MINEVAL, CP.MAXEVAL_2nd, CP.NNEW, CP.NMIN, CP.FLATNESS,
 					CP.STATEFILE, CP.SPIN,
 					&CP.nregions, &CP.neval, &CP.fail, integral, error, prob);
-
 			sigma_hp_2nd_l2k2 = integral[CP.comp]*nb;
 			sigma_hp_2nd_l2k2_error = error[CP.comp]*nb;
 		}
-
 		if (param.flag[param.int_method] == 2) {
-
-			llCuhre(CP.NDIM_brems_2nd_2diff, CP.NCOMP, integrands.cuba_integrand_brems_2nd_l1k1_2diff,
+			llCuhre(CP.NDIM_brems_2nd_2diff, CP.NCOMP, 
+                    integrands.cuba_integrand_brems_2nd_l1k1_2diff,
 					USERDATA, CP.NVEC, CP.EPSREL, CP.EPSABS, CP.flags_brems | 4,
 					CP.MINEVAL, CP.MAXEVAL_2nd, CP.KEY,
 					CP.STATEFILE, CP.SPIN,
 					&CP.nregions, &CP.neval, &CP.fail, integral, error, prob);
-
 			sigma_hp_2nd_l1k1 = integral[CP.comp]*nb;
 			sigma_hp_2nd_l1k1_error = error[CP.comp]*nb;
-
-			llCuhre(CP.NDIM_brems_2nd_2diff, CP.NCOMP, integrands.cuba_integrand_brems_2nd_l1k2_2diff,
+			llCuhre(CP.NDIM_brems_2nd_2diff, CP.NCOMP, 
+                    integrands.cuba_integrand_brems_2nd_l1k2_2diff,
 					USERDATA, CP.NVEC, CP.EPSREL, CP.EPSABS, CP.flags_brems | 4,
 					CP.MINEVAL, CP.MAXEVAL_2nd, CP.KEY,
 					CP.STATEFILE, CP.SPIN,
 					&CP.nregions, &CP.neval, &CP.fail, integral, error, prob);
-
 			sigma_hp_2nd_l1k2 = integral[CP.comp]*nb;
 			sigma_hp_2nd_l1k2_error = error[CP.comp]*nb;
-
-			llCuhre(CP.NDIM_brems_2nd_2diff, CP.NCOMP, integrands.cuba_integrand_brems_2nd_l2k1_2diff,
+			llCuhre(CP.NDIM_brems_2nd_2diff, CP.NCOMP, 
+                    integrands.cuba_integrand_brems_2nd_l2k1_2diff,
 					USERDATA, CP.NVEC, CP.EPSREL, CP.EPSABS, CP.flags_brems | 4,
 					CP.MINEVAL, CP.MAXEVAL_2nd, CP.KEY,
 					CP.STATEFILE, CP.SPIN,
 					&CP.nregions, &CP.neval, &CP.fail, integral, error, prob);
-
 			sigma_hp_2nd_l2k1 = integral[CP.comp]*nb;
 			sigma_hp_2nd_l2k1_error = error[CP.comp]*nb;
-
-			llCuhre(CP.NDIM_brems_2nd_2diff, CP.NCOMP, integrands.cuba_integrand_brems_2nd_l2k2_2diff,
+			llCuhre(CP.NDIM_brems_2nd_2diff, CP.NCOMP, 
+                    integrands.cuba_integrand_brems_2nd_l2k2_2diff,
 					USERDATA, CP.NVEC, CP.EPSREL, CP.EPSABS, CP.flags_brems | 4,
 					CP.MINEVAL, CP.MAXEVAL_2nd, CP.KEY,
 					CP.STATEFILE, CP.SPIN,
 					&CP.nregions, &CP.neval, &CP.fail, integral, error, prob);
-
 			sigma_hp_2nd_l2k2 = integral[CP.comp]*nb;
 			sigma_hp_2nd_l2k2_error = error[CP.comp]*nb;
 		}
-
-		output.sigma_unpol_inelastic_2nd = sigma_hp_2nd_l1k1 + sigma_hp_2nd_l1k2 + sigma_hp_2nd_l2k1 + sigma_hp_2nd_l2k2;
-		errors.sigma_unpol_inelastic_2nd = sqrt(pow(sigma_hp_2nd_l1k1_error,2.) + pow(sigma_hp_2nd_l1k2_error,2.)
-											+ pow(sigma_hp_2nd_l2k1_error,2.) + pow(sigma_hp_2nd_l2k2_error,2.));
+		output.sigma_unpol_inelastic_2nd = sigma_hp_2nd_l1k1 + 
+                                           sigma_hp_2nd_l1k2 + 
+                                           sigma_hp_2nd_l2k1 + 
+                                           sigma_hp_2nd_l2k2;
+		errors.sigma_unpol_inelastic_2nd = sqrt(pow(sigma_hp_2nd_l1k1_error,2.) + 
+                                                pow(sigma_hp_2nd_l1k2_error,2.) + 
+                                                pow(sigma_hp_2nd_l2k1_error,2.) + 
+                                                pow(sigma_hp_2nd_l2k2_error,2.));
 
 	}
+// End section bremsstrahlung type = 5
 
+// brems=6: 2nd order 1-fold differential in theta'_gamma 
 	if (param.flag[param.brems] == 6) {
-
 		llVegas(CP.NDIM_brems_2nd_1diff, CP.NCOMP, integrands.cuba_integrand_brems_2nd_1diff,
 				USERDATA, CP.NVEC, CP.EPSREL, CP.EPSABS, CP.flags, CP.SEED,
 				CP.MINEVAL, 1e8, CP.NSTART, CP.NINCREASE, CP.NBATCH,
 				CP.GRIDNO_brems_2nd, CP.STATEFILE, CP.SPIN,
 				&CP.neval, &CP.fail, integral, error, prob);
-
 		llVegas(CP.NDIM_brems_2nd_1diff, CP.NCOMP, integrands.cuba_integrand_brems_2nd_1diff,
 				USERDATA, CP.NVEC, CP.EPSREL, CP.EPSABS, CP.flags, CP.SEED,
 				CP.MINEVAL, CP.MAXEVAL_2nd, CP.NSTART, CP.NINCREASE, CP.NBATCH,
 				CP.GRIDNO_brems_2nd, CP.STATEFILE, CP.SPIN,
 				&CP.neval, &CP.fail, integral, error, prob);
-
 		output.sigma_unpol_inelastic_2nd = integral[CP.comp]*nb;
 		errors.sigma_unpol_inelastic_2nd = error[CP.comp]*nb;
 	}
+// End section bremsstrahlung type = 6
 
+// brems=7: 1st order 2-fold differential in theta_l and E' 
 	if (param.flag[param.brems] == 7) {
-
 		llVegas(CP.NDIM_brems_1st_2diff, CP.NCOMP, integrands.cuba_integrand_brems_1st_2diff_v2,
 				USERDATA, CP.NVEC, CP.EPSREL, CP.EPSABS, CP.flags, CP.SEED,
 				CP.MINEVAL, CP.MAXEVAL_2nd, CP.NSTART, CP.NINCREASE, CP.NBATCH,
 				CP.GRIDNO, CP.STATEFILE, CP.SPIN,
 				&CP.neval, &CP.fail, integral, error, prob);
-
 		output.sigma_unpol_inelastic_1st = integral[CP.comp]*nb;
 		errors.sigma_unpol_inelastic_1st = error[CP.comp]*nb;
 	}
+// End section bremsstrahlung type = 7
 
+// brems=8: 1st order 3-fold differential in theta_l, theta_gamma and phi_gamma 
 	if (param.flag[param.brems] == 8) {
-
 		llSuave(CP.NDIM_ELASTIC, CP.NCOMP, integrands.cuba_integrand_brems_1st_ps2_3diff,
 				USERDATA, CP.NVEC, CP.EPSREL, CP.EPSABS, CP.flags_brems | 4, CP.SEED,
 				CP.MINEVAL, CP.MAXEVAL_1st, CP.NNEW, CP.NMIN, CP.FLATNESS,
 				CP.STATEFILE, CP.SPIN,
 				&CP.nregions, &CP.neval, &CP.fail, integral, error, prob);
-
 		output.sigma_unpol_inelastic_1st = integral[CP.comp]*nb;
 		errors.sigma_unpol_inelastic_1st = error[CP.comp]*nb;
 	}
+// End section bremsstrahlung type = 8
 
-	if (param.flag[param.brems] == 9) {
 
-		llSuave(CP.NDIM_brems_1st, CP.NCOMP, integrands.cuba_integrand_brems_1st_sg_diff,
-				USERDATA, CP.NVEC, CP.EPSREL, CP.EPSABS, CP.flags_brems | 4, CP.SEED,
-				CP.MINEVAL, CP.MAXEVAL_1st, CP.NNEW, CP.NMIN, CP.FLATNESS,
-				CP.STATEFILE, CP.SPIN,
-				&CP.nregions, &CP.neval, &CP.fail, integral, error, prob);
-
-		output.sigma_unpol_inelastic_1st = integral[CP.comp]*nb;
-		errors.sigma_unpol_inelastic_1st = error[CP.comp]*nb;
-	}
-
-	if (param.flag[param.brems] == 10) {
-
-		double sigma_add_l1k1, sigma_add_l1k2, sigma_add_l2k1, sigma_add_l2k2;
-		double error_sigma_add_l1k1, error_sigma_add_l1k2, error_sigma_add_l2k1, error_sigma_add_l2k2;
-
-//		llSuave(CP.NDIM_brems_2nd_2diff, CP.NCOMP, integrands.cuba_integrand_brems_2nd_add_2diff,
-//				USERDATA, CP.NVEC, CP.EPSREL, CP.EPSABS, CP.flags_brems | 4, CP.SEED,
-//				CP.MINEVAL, CP.MAXEVAL_2nd_add, CP.NNEW, CP.NMIN, CP.FLATNESS,
-//				CP.STATEFILE, CP.SPIN,
-//				&CP.nregions, &CP.neval, &CP.fail, integral, error, prob);
-//
-//		output.sigma_unpol_2nd_add = integral[CP.comp]*nb;
-//		std::cout << output.sigma_unpol_2nd_add << "\n";
-
-		llSuave(CP.NDIM_brems_2nd_2diff, CP.NCOMP, integrands.cuba_integrand_brems_2nd_add_l1k1_2diff,
-				USERDATA, CP.NVEC, CP.EPSREL, CP.EPSABS, CP.flags_brems | 4, CP.SEED,
-				CP.MINEVAL, CP.MAXEVAL_2nd_add, CP.NNEW, CP.NMIN, CP.FLATNESS,
-				CP.STATEFILE, CP.SPIN,
-				&CP.nregions, &CP.neval, &CP.fail, integral, error, prob);
-
-		sigma_add_l1k1 = integral[CP.comp]*nb;
-		error_sigma_add_l1k1 = error[CP.comp]*nb;
-//		std::cout << sigma_add_l1k1 << "\n";
-
-		llSuave(CP.NDIM_brems_2nd_2diff, CP.NCOMP, integrands.cuba_integrand_brems_2nd_add_l1k2_2diff,
-				USERDATA, CP.NVEC, CP.EPSREL, CP.EPSABS, CP.flags_brems | 4, CP.SEED,
-				CP.MINEVAL, CP.MAXEVAL_2nd_add, CP.NNEW, CP.NMIN, CP.FLATNESS,
-				CP.STATEFILE, CP.SPIN,
-				&CP.nregions, &CP.neval, &CP.fail, integral, error, prob);
-
-		sigma_add_l1k2 = integral[CP.comp]*nb;
-		error_sigma_add_l1k2 = error[CP.comp]*nb;
-//		std::cout << sigma_add_l1k2 << "\n";
-
-		llSuave(CP.NDIM_brems_2nd_2diff, CP.NCOMP, integrands.cuba_integrand_brems_2nd_add_l2k1_2diff,
-				USERDATA, CP.NVEC, CP.EPSREL, CP.EPSABS, CP.flags_brems | 4, CP.SEED,
-				CP.MINEVAL, CP.MAXEVAL_2nd_add, CP.NNEW, CP.NMIN, CP.FLATNESS,
-				CP.STATEFILE, CP.SPIN,
-				&CP.nregions, &CP.neval, &CP.fail, integral, error, prob);
-
-		sigma_add_l2k1 = integral[CP.comp]*nb;
-		error_sigma_add_l2k1 = error[CP.comp]*nb;
-//		std::cout << sigma_add_l2k1 << "\n";
-
-		llSuave(CP.NDIM_brems_2nd_2diff, CP.NCOMP, integrands.cuba_integrand_brems_2nd_add_l2k2_2diff,
-				USERDATA, CP.NVEC, CP.EPSREL, CP.EPSABS, CP.flags_brems | 4, CP.SEED,
-				CP.MINEVAL, CP.MAXEVAL_2nd_add, CP.NNEW, CP.NMIN, CP.FLATNESS,
-				CP.STATEFILE, CP.SPIN,
-				&CP.nregions, &CP.neval, &CP.fail, integral, error, prob);
-
-		sigma_add_l2k2 = integral[CP.comp]*nb;
-		error_sigma_add_l2k2 = error[CP.comp]*nb;
-//		std::cout << sigma_add_l2k2 << "\n";
-
-		output.sigma_unpol_2nd_add = sigma_add_l1k1 + sigma_add_l2k1 + sigma_add_l1k2 + sigma_add_l2k2;
-		errors.sigma_unpol_2nd_add = sqrt(pow(error_sigma_add_l1k1,2.) + pow(error_sigma_add_l2k1,2.)
-				+ pow(error_sigma_add_l1k2,2.) + pow(error_sigma_add_l2k2,2.));
-
-	}
-
-	if (param.flag[param.brems] == 11) {
-
-		double sigma_add_l1k1_1, sigma_add_l1k1_2, sigma_add_l1k2_1, sigma_add_l1k2_2,
-		sigma_add_l2k1_1, sigma_add_l2k1_2, sigma_add_l2k2_1, sigma_add_l2k2_2;
-		double error_sigma_add_l1k1_1, error_sigma_add_l1k1_2, error_sigma_add_l1k2_1,
-		error_sigma_add_l1k2_2, error_sigma_add_l2k1_1, error_sigma_add_l2k1_2,
-		error_sigma_add_l2k2_1, error_sigma_add_l2k2_2;
-
-		std::cout << "Numerical integration for one hard-photon and one soft-photon finite contribution ... ";
-
-		if (param.flag[param.int_method] == 0) {
-			llVegas(CP.NDIM_brems_2nd, CP.NCOMP, integrands.cuba_integrand_brems_2nd_add_l1k1_1,
-					USERDATA, CP.NVEC, CP.EPSREL, CP.EPSABS, CP.flags, CP.SEED,
-					CP.MINEVAL, 1e8, CP.NSTART, CP.NINCREASE, CP.NBATCH,
-					CP.GRIDNO_brems_2nd_l1k1, CP.STATEFILE, CP.SPIN,
-					&CP.neval, &CP.fail, integral, error, prob);
-
-			llVegas(CP.NDIM_brems_2nd, CP.NCOMP, integrands.cuba_integrand_brems_2nd_add_l1k1_1,
-					USERDATA, CP.NVEC, CP.EPSREL, CP.EPSABS, CP.flags, CP.SEED,
-					CP.MINEVAL, CP.MAXEVAL_2nd, CP.NSTART, CP.NINCREASE, CP.NBATCH,
-					CP.GRIDNO_brems_2nd_l1k1, CP.STATEFILE, CP.SPIN,
-					&CP.neval, &CP.fail, integral, error, prob);
-
-			sigma_add_l1k1_1 = integral[CP.comp]*nb;
-			error_sigma_add_l1k1_1 = error[CP.comp]*nb;
-
-			llVegas(CP.NDIM_brems_2nd, CP.NCOMP, integrands.cuba_integrand_brems_2nd_add_l1k1_2,
-					USERDATA, CP.NVEC, CP.EPSREL, CP.EPSABS, CP.flags, CP.SEED,
-					CP.MINEVAL, 1e8, CP.NSTART, CP.NINCREASE, CP.NBATCH,
-					CP.GRIDNO_brems_2nd_add_l1k1, CP.STATEFILE, CP.SPIN,
-					&CP.neval, &CP.fail, integral, error, prob);
-
-			llVegas(CP.NDIM_brems_2nd, CP.NCOMP, integrands.cuba_integrand_brems_2nd_add_l1k1_2,
-					USERDATA, CP.NVEC, CP.EPSREL, CP.EPSABS, CP.flags, CP.SEED,
-					CP.MINEVAL, CP.MAXEVAL_2nd, CP.NSTART, CP.NINCREASE, CP.NBATCH,
-					CP.GRIDNO_brems_2nd_add_l1k1, CP.STATEFILE, CP.SPIN,
-					&CP.neval, &CP.fail, integral, error, prob);
-
-			sigma_add_l1k1_2 = integral[CP.comp]*nb;
-			error_sigma_add_l1k1_2 = error[CP.comp]*nb;
-
-			llVegas(CP.NDIM_brems_2nd, CP.NCOMP, integrands.cuba_integrand_brems_2nd_add_l1k2_1,
-					USERDATA, CP.NVEC, CP.EPSREL, CP.EPSABS, CP.flags, CP.SEED,
-					CP.MINEVAL, 1e8, CP.NSTART, CP.NINCREASE, CP.NBATCH,
-					CP.GRIDNO_brems_2nd_l1k2, CP.STATEFILE, CP.SPIN,
-					&CP.neval, &CP.fail, integral, error, prob);
-
-			llVegas(CP.NDIM_brems_2nd, CP.NCOMP, integrands.cuba_integrand_brems_2nd_add_l1k2_1,
-					USERDATA, CP.NVEC, CP.EPSREL, CP.EPSABS, CP.flags, CP.SEED,
-					CP.MINEVAL, CP.MAXEVAL_2nd, CP.NSTART, CP.NINCREASE, CP.NBATCH,
-					CP.GRIDNO_brems_2nd_l1k2, CP.STATEFILE, CP.SPIN,
-					&CP.neval, &CP.fail, integral, error, prob);
-
-			sigma_add_l1k2_1 = integral[CP.comp]*nb;
-			error_sigma_add_l1k2_1 = error[CP.comp]*nb;
-
-			llVegas(CP.NDIM_brems_2nd, CP.NCOMP, integrands.cuba_integrand_brems_2nd_add_l1k2_2,
-					USERDATA, CP.NVEC, CP.EPSREL, CP.EPSABS, CP.flags, CP.SEED,
-					CP.MINEVAL, 1e8, CP.NSTART, CP.NINCREASE, CP.NBATCH,
-					CP.GRIDNO_brems_2nd_add_l1k2, CP.STATEFILE, CP.SPIN,
-					&CP.neval, &CP.fail, integral, error, prob);
-
-			llVegas(CP.NDIM_brems_2nd, CP.NCOMP, integrands.cuba_integrand_brems_2nd_add_l1k2_2,
-					USERDATA, CP.NVEC, CP.EPSREL, CP.EPSABS, CP.flags, CP.SEED,
-					CP.MINEVAL, CP.MAXEVAL_2nd, CP.NSTART, CP.NINCREASE, CP.NBATCH,
-					CP.GRIDNO_brems_2nd_add_l1k2, CP.STATEFILE, CP.SPIN,
-					&CP.neval, &CP.fail, integral, error, prob);
-
-			sigma_add_l1k2_2 = integral[CP.comp]*nb;
-			error_sigma_add_l1k2_2 = error[CP.comp]*nb;
-
-			llVegas(CP.NDIM_brems_2nd, CP.NCOMP, integrands.cuba_integrand_brems_2nd_add_l2k1_1,
-					USERDATA, CP.NVEC, CP.EPSREL, CP.EPSABS, CP.flags, CP.SEED,
-					CP.MINEVAL, 1e8, CP.NSTART, CP.NINCREASE, CP.NBATCH,
-					CP.GRIDNO_brems_2nd_l2k1, CP.STATEFILE, CP.SPIN,
-					&CP.neval, &CP.fail, integral, error, prob);
-
-			llVegas(CP.NDIM_brems_2nd, CP.NCOMP, integrands.cuba_integrand_brems_2nd_add_l2k1_1,
-					USERDATA, CP.NVEC, CP.EPSREL, CP.EPSABS, CP.flags, CP.SEED,
-					CP.MINEVAL, CP.MAXEVAL_2nd, CP.NSTART, CP.NINCREASE, CP.NBATCH,
-					CP.GRIDNO_brems_2nd_l2k1, CP.STATEFILE, CP.SPIN,
-					&CP.neval, &CP.fail, integral, error, prob);
-
-			sigma_add_l2k1_1 = integral[CP.comp]*nb;
-			error_sigma_add_l2k1_1 = error[CP.comp]*nb;
-
-			llVegas(CP.NDIM_brems_2nd, CP.NCOMP, integrands.cuba_integrand_brems_2nd_add_l2k1_2,
-					USERDATA, CP.NVEC, CP.EPSREL, CP.EPSABS, CP.flags, CP.SEED,
-					CP.MINEVAL, 1e8, CP.NSTART, CP.NINCREASE, CP.NBATCH,
-					CP.GRIDNO_brems_2nd_add_l2k1, CP.STATEFILE, CP.SPIN,
-					&CP.neval, &CP.fail, integral, error, prob);
-
-			llVegas(CP.NDIM_brems_2nd, CP.NCOMP, integrands.cuba_integrand_brems_2nd_add_l2k1_2,
-					USERDATA, CP.NVEC, CP.EPSREL, CP.EPSABS, CP.flags, CP.SEED,
-					CP.MINEVAL, CP.MAXEVAL_2nd, CP.NSTART, CP.NINCREASE, CP.NBATCH,
-					CP.GRIDNO_brems_2nd_add_l2k1, CP.STATEFILE, CP.SPIN,
-					&CP.neval, &CP.fail, integral, error, prob);
-
-			sigma_add_l2k1_2 = integral[CP.comp]*nb;
-			error_sigma_add_l2k1_2 = error[CP.comp]*nb;
-
-			llVegas(CP.NDIM_brems_2nd, CP.NCOMP, integrands.cuba_integrand_brems_2nd_add_l1k1_1,
-					USERDATA, CP.NVEC, CP.EPSREL, CP.EPSABS, CP.flags, CP.SEED,
-					CP.MINEVAL, 1e8, CP.NSTART, CP.NINCREASE, CP.NBATCH,
-					CP.GRIDNO_brems_2nd_l1k1, CP.STATEFILE, CP.SPIN,
-					&CP.neval, &CP.fail, integral, error, prob);
-
-			llVegas(CP.NDIM_brems_2nd, CP.NCOMP, integrands.cuba_integrand_brems_2nd_add_l2k2_1,
-					USERDATA, CP.NVEC, CP.EPSREL, CP.EPSABS, CP.flags, CP.SEED,
-					CP.MINEVAL, CP.MAXEVAL_2nd, CP.NSTART, CP.NINCREASE, CP.NBATCH,
-					CP.GRIDNO_brems_2nd_l2k2, CP.STATEFILE, CP.SPIN,
-					&CP.neval, &CP.fail, integral, error, prob);
-
-			sigma_add_l2k2_1 = integral[CP.comp]*nb;
-			error_sigma_add_l2k2_1 = error[CP.comp]*nb;
-
-			llVegas(CP.NDIM_brems_2nd, CP.NCOMP, integrands.cuba_integrand_brems_2nd_add_l2k2_2,
-					USERDATA, CP.NVEC, CP.EPSREL, CP.EPSABS, CP.flags, CP.SEED,
-					CP.MINEVAL, 1e8, CP.NSTART, CP.NINCREASE, CP.NBATCH,
-					CP.GRIDNO_brems_2nd_add_l2k2, CP.STATEFILE, CP.SPIN,
-					&CP.neval, &CP.fail, integral, error, prob);
-
-			llVegas(CP.NDIM_brems_2nd, CP.NCOMP, integrands.cuba_integrand_brems_2nd_add_l2k2_2,
-					USERDATA, CP.NVEC, CP.EPSREL, CP.EPSABS, CP.flags, CP.SEED,
-					CP.MINEVAL, CP.MAXEVAL_2nd, CP.NSTART, CP.NINCREASE, CP.NBATCH,
-					CP.GRIDNO_brems_2nd_add_l2k2, CP.STATEFILE, CP.SPIN,
-					&CP.neval, &CP.fail, integral, error, prob);
-
-			sigma_add_l2k2_2 = integral[CP.comp]*nb;
-			error_sigma_add_l2k2_2 = error[CP.comp]*nb;
-
-		}
-
-		if (param.flag[param.int_method] == 1) {
-			llSuave(CP.NDIM_brems_2nd, CP.NCOMP, integrands.cuba_integrand_brems_2nd_add_l1k1_1,
-					USERDATA, CP.NVEC, CP.EPSREL, CP.EPSABS, CP.flags_brems | 4, CP.SEED,
-					CP.MINEVAL, CP.MAXEVAL_2nd_add, CP.NNEW, CP.NMIN, CP.FLATNESS,
-					CP.STATEFILE, CP.SPIN,
-					&CP.nregions, &CP.neval, &CP.fail, integral, error, prob);
-
-			sigma_add_l1k1_1 = integral[CP.comp]*nb;
-			error_sigma_add_l1k1_1 = error[CP.comp]*nb;
-
-			llSuave(CP.NDIM_brems_2nd, CP.NCOMP, integrands.cuba_integrand_brems_2nd_add_l1k1_2,
-					USERDATA, CP.NVEC, CP.EPSREL, CP.EPSABS, CP.flags_brems | 4, CP.SEED,
-					CP.MINEVAL, CP.MAXEVAL_2nd_add, CP.NNEW, CP.NMIN, CP.FLATNESS,
-					CP.STATEFILE, CP.SPIN,
-					&CP.nregions, &CP.neval, &CP.fail, integral, error, prob);
-
-			sigma_add_l1k1_2 = integral[CP.comp]*nb;
-			error_sigma_add_l1k1_2 = error[CP.comp]*nb;
-
-			llSuave(CP.NDIM_brems_2nd, CP.NCOMP, integrands.cuba_integrand_brems_2nd_add_l2k1_1,
-					USERDATA, CP.NVEC, CP.EPSREL, CP.EPSABS, CP.flags_brems | 4, CP.SEED,
-					CP.MINEVAL, CP.MAXEVAL_2nd_add, CP.NNEW, CP.NMIN, CP.FLATNESS,
-					CP.STATEFILE, CP.SPIN,
-					&CP.nregions, &CP.neval, &CP.fail, integral, error, prob);
-
-			sigma_add_l2k1_1 = integral[CP.comp]*nb;
-			error_sigma_add_l2k1_1 = error[CP.comp]*nb;
-
-			llSuave(CP.NDIM_brems_2nd, CP.NCOMP, integrands.cuba_integrand_brems_2nd_add_l2k1_2,
-					USERDATA, CP.NVEC, CP.EPSREL, CP.EPSABS, CP.flags_brems | 4, CP.SEED,
-					CP.MINEVAL, CP.MAXEVAL_2nd_add, CP.NNEW, CP.NMIN, CP.FLATNESS,
-					CP.STATEFILE, CP.SPIN,
-					&CP.nregions, &CP.neval, &CP.fail, integral, error, prob);
-
-			sigma_add_l2k1_2 = integral[CP.comp]*nb;
-			error_sigma_add_l2k1_2 = error[CP.comp]*nb;
-
-			llSuave(CP.NDIM_brems_2nd, CP.NCOMP, integrands.cuba_integrand_brems_2nd_add_l1k2_1,
-					USERDATA, CP.NVEC, CP.EPSREL, CP.EPSABS, CP.flags_brems | 4, CP.SEED,
-					CP.MINEVAL, CP.MAXEVAL_2nd_add, CP.NNEW, CP.NMIN, CP.FLATNESS,
-					CP.STATEFILE, CP.SPIN,
-					&CP.nregions, &CP.neval, &CP.fail, integral, error, prob);
-
-			sigma_add_l1k2_1 = integral[CP.comp]*nb;
-			error_sigma_add_l1k2_1 = error[CP.comp]*nb;
-
-			llSuave(CP.NDIM_brems_2nd, CP.NCOMP, integrands.cuba_integrand_brems_2nd_add_l1k2_2,
-					USERDATA, CP.NVEC, CP.EPSREL, CP.EPSABS, CP.flags_brems | 4, CP.SEED,
-					CP.MINEVAL, CP.MAXEVAL_2nd_add, CP.NNEW, CP.NMIN, CP.FLATNESS,
-					CP.STATEFILE, CP.SPIN,
-					&CP.nregions, &CP.neval, &CP.fail, integral, error, prob);
-
-			sigma_add_l1k2_2 = integral[CP.comp]*nb;
-			error_sigma_add_l1k2_2 = error[CP.comp]*nb;
-
-			llSuave(CP.NDIM_brems_2nd, CP.NCOMP, integrands.cuba_integrand_brems_2nd_add_l2k2_1,
-					USERDATA, CP.NVEC, CP.EPSREL, CP.EPSABS, CP.flags_brems | 4, CP.SEED,
-					CP.MINEVAL, CP.MAXEVAL_2nd_add, CP.NNEW, CP.NMIN, CP.FLATNESS,
-					CP.STATEFILE, CP.SPIN,
-					&CP.nregions, &CP.neval, &CP.fail, integral, error, prob);
-
-			sigma_add_l2k2_1 = integral[CP.comp]*nb;
-			error_sigma_add_l2k2_1 = error[CP.comp]*nb;
-
-			llSuave(CP.NDIM_brems_2nd, CP.NCOMP, integrands.cuba_integrand_brems_2nd_add_l2k2_2,
-					USERDATA, CP.NVEC, CP.EPSREL, CP.EPSABS, CP.flags_brems | 4, CP.SEED,
-					CP.MINEVAL, CP.MAXEVAL_2nd_add, CP.NNEW, CP.NMIN, CP.FLATNESS,
-					CP.STATEFILE, CP.SPIN,
-					&CP.nregions, &CP.neval, &CP.fail, integral, error, prob);
-
-			sigma_add_l2k2_2 = integral[CP.comp]*nb;
-			error_sigma_add_l2k2_2 = error[CP.comp]*nb;
-		}
-
-		double sigma_add_l1k1 = sigma_add_l1k1_1 + sigma_add_l1k1_2;
-		double error_sigma_add_l1k1 = sqrt(pow(error_sigma_add_l1k1_1,2.)+pow(error_sigma_add_l1k1_2,2.));
-		double sigma_add_l1k2 = sigma_add_l1k2_1 + sigma_add_l1k2_2;
-		double error_sigma_add_l1k2 = sqrt(pow(error_sigma_add_l1k2_1,2.)+pow(error_sigma_add_l1k2_2,2.));
-		double sigma_add_l2k1 = sigma_add_l2k1_1 + sigma_add_l2k1_2;
-		double error_sigma_add_l2k1 = sqrt(pow(error_sigma_add_l2k1_1,2.)+pow(error_sigma_add_l2k1_2,2.));
-		double sigma_add_l2k2 = sigma_add_l2k2_1 + sigma_add_l2k2_2;
-		double error_sigma_add_l2k2 = sqrt(pow(error_sigma_add_l2k2_1,2.)+pow(error_sigma_add_l2k2_2,2.));
-
-		output.sigma_unpol_2nd_add = sigma_add_l1k1 + sigma_add_l2k1 + sigma_add_l1k2 + sigma_add_l2k2;
-		errors.sigma_unpol_2nd_add = sqrt(pow(error_sigma_add_l1k1,2.) + pow(error_sigma_add_l2k1,2.)
-				+ pow(error_sigma_add_l1k2,2.) + pow(error_sigma_add_l2k2,2.));
-
-		std::cout <<"completed\n";
-	}
-
-	if (param.flag[param.brems] == 12) {
-
-		std::cout << "Numerical integration for two hard-photons unpolarized cross-section ... ";
-
-	    double sigma_2hp_l1k1_1, sigma_2hp_l1k1_2, sigma_2hp_l1k2_1, sigma_2hp_l1k2_2,
-	    sigma_2hp_l2k1_1, sigma_2hp_l2k1_2, sigma_2hp_l2k2_1, sigma_2hp_l2k2_2;
-	    double error_sigma_2hp_l1k1_1, error_sigma_2hp_l1k1_2, error_sigma_2hp_l1k2_1,
-	    error_sigma_2hp_l1k2_2, error_sigma_2hp_l2k1_1, error_sigma_2hp_l2k1_2,
-	    error_sigma_2hp_l2k2_1, error_sigma_2hp_l2k2_2;
-
-	    if (param.flag[param.int_method] == 0) {
-//	      llVegas(CP.NDIM_brems_2nd, CP.NCOMP, integrands.cuba_integrand_brems_2nd_l1k1_1,
-//	          USERDATA, CP.NVEC, CP.EPSREL, CP.EPSABS, CP.flags, CP.SEED,
-//	          CP.MINEVAL, 1e8, CP.NSTART, CP.NINCREASE, CP.NBATCH,
-//	          CP.GRIDNO_brems_2nd_l1k1, CP.STATEFILE, CP.SPIN,
-//	          &CP.neval, &CP.fail, integral, error, prob);
-//
-//	      llVegas(CP.NDIM_brems_2nd, CP.NCOMP, integrands.cuba_integrand_brems_2nd_l1k1_1,
-//	          USERDATA, CP.NVEC, CP.EPSREL, CP.EPSABS, CP.flags, CP.SEED,
-//	          CP.MINEVAL, CP.MAXEVAL_2nd, CP.NSTART, CP.NINCREASE, CP.NBATCH,
-//	          CP.GRIDNO_brems_2nd_l1k1, CP.STATEFILE, CP.SPIN,
-//	          &CP.neval, &CP.fail, integral, error, prob);
-//
-//	      sigma_2hp_l1k1_1 = integral[CP.comp]*nb;
-//	      error_sigma_2hp_l1k1_1 = error[CP.comp]*nb;
-//
-//	      llVegas(CP.NDIM_brems_2nd, CP.NCOMP, integrands.cuba_integrand_brems_2nd_l1k2_1,
-//	          USERDATA, CP.NVEC, CP.EPSREL, CP.EPSABS, CP.flags, CP.SEED,
-//	          CP.MINEVAL, 1e8, CP.NSTART, CP.NINCREASE, CP.NBATCH,
-//	          CP.GRIDNO_brems_2nd_l1k2, CP.STATEFILE, CP.SPIN,
-//	          &CP.neval, &CP.fail, integral, error, prob);
-//
-//	      llVegas(CP.NDIM_brems_2nd, CP.NCOMP, integrands.cuba_integrand_brems_2nd_l1k2_1,
-//	          USERDATA, CP.NVEC, CP.EPSREL, CP.EPSABS, CP.flags, CP.SEED,
-//	          CP.MINEVAL, CP.MAXEVAL_2nd, CP.NSTART, CP.NINCREASE, CP.NBATCH,
-//	          CP.GRIDNO_brems_2nd_l1k2, CP.STATEFILE, CP.SPIN,
-//	          &CP.neval, &CP.fail, integral, error, prob);
-//
-//	      sigma_2hp_l1k2_1 = integral[CP.comp]*nb;
-//	      error_sigma_2hp_l1k2_1 = error[CP.comp]*nb;
-//
-//	      llVegas(CP.NDIM_brems_2nd, CP.NCOMP, integrands.cuba_integrand_brems_2nd_l2k1_1,
-//	          USERDATA, CP.NVEC, CP.EPSREL, CP.EPSABS, CP.flags, CP.SEED,
-//	          CP.MINEVAL, 1e8, CP.NSTART, CP.NINCREASE, CP.NBATCH,
-//	          CP.GRIDNO_brems_2nd_l2k1, CP.STATEFILE, CP.SPIN,
-//	          &CP.neval, &CP.fail, integral, error, prob);
-//
-//	      llVegas(CP.NDIM_brems_2nd, CP.NCOMP, integrands.cuba_integrand_brems_2nd_l2k1_1,
-//	          USERDATA, CP.NVEC, CP.EPSREL, CP.EPSABS, CP.flags, CP.SEED,
-//	          CP.MINEVAL, CP.MAXEVAL_2nd, CP.NSTART, CP.NINCREASE, CP.NBATCH,
-//	          CP.GRIDNO_brems_2nd_l2k1, CP.STATEFILE, CP.SPIN,
-//	          &CP.neval, &CP.fail, integral, error, prob);
-//
-//	      sigma_2hp_l2k1_1 = integral[CP.comp]*nb;
-//	      error_sigma_2hp_l2k1_1 = error[CP.comp]*nb;
-//
-	      llVegas(CP.NDIM_brems_2nd, CP.NCOMP, integrands.cuba_integrand_brems_2nd_l2k2_1,
-	          USERDATA, CP.NVEC, CP.EPSREL, CP.EPSABS, CP.flags, CP.SEED,
-	          CP.MINEVAL, 1e8, CP.NSTART, CP.NINCREASE, CP.NBATCH,
-	          CP.GRIDNO_brems_2nd_l1k1, CP.STATEFILE, CP.SPIN,
-	          &CP.neval, &CP.fail, integral, error, prob);
-
-	      llVegas(CP.NDIM_brems_2nd, CP.NCOMP, integrands.cuba_integrand_brems_2nd_l2k2_1,
-	          USERDATA, CP.NVEC, CP.EPSREL, CP.EPSABS, CP.flags, CP.SEED,
-	          CP.MINEVAL, CP.MAXEVAL_2nd, CP.NSTART, CP.NINCREASE, CP.NBATCH,
-	          CP.GRIDNO_brems_2nd_l2k2, CP.STATEFILE, CP.SPIN,
-	          &CP.neval, &CP.fail, integral, error, prob);
-
-	      sigma_2hp_l2k2_1 = integral[CP.comp]*nb;
-	      error_sigma_2hp_l2k2_1 = error[CP.comp]*nb;
-//
-//	      llVegas(CP.NDIM_brems_2nd, CP.NCOMP, integrands.cuba_integrand_brems_2nd_l1k1_2,
-//	          USERDATA, CP.NVEC, CP.EPSREL, CP.EPSABS, CP.flags, CP.SEED,
-//	          CP.MINEVAL, 1e8, CP.NSTART, CP.NINCREASE, CP.NBATCH,
-//	          CP.GRIDNO_brems_2nd_add_l1k1, CP.STATEFILE, CP.SPIN,
-//	          &CP.neval, &CP.fail, integral, error, prob);
-//
-//	      llVegas(CP.NDIM_brems_2nd, CP.NCOMP, integrands.cuba_integrand_brems_2nd_l1k1_2,
-//	          USERDATA, CP.NVEC, CP.EPSREL, CP.EPSABS, CP.flags, CP.SEED,
-//	          CP.MINEVAL, CP.MAXEVAL_2nd, CP.NSTART, CP.NINCREASE, CP.NBATCH,
-//	          CP.GRIDNO_brems_2nd_add_l1k1, CP.STATEFILE, CP.SPIN,
-//	          &CP.neval, &CP.fail, integral, error, prob);
-//
-//	      sigma_2hp_l1k1_2 = integral[CP.comp]*nb;
-//	      error_sigma_2hp_l1k1_2 = error[CP.comp]*nb;
-//
-//	      llVegas(CP.NDIM_brems_2nd, CP.NCOMP, integrands.cuba_integrand_brems_2nd_l1k2_2,
-//	          USERDATA, CP.NVEC, CP.EPSREL, CP.EPSABS, CP.flags, CP.SEED,
-//	          CP.MINEVAL, 1e8, CP.NSTART, CP.NINCREASE, CP.NBATCH,
-//	          CP.GRIDNO_brems_2nd_add_l1k2, CP.STATEFILE, CP.SPIN,
-//	          &CP.neval, &CP.fail, integral, error, prob);
-//
-//	      llVegas(CP.NDIM_brems_2nd, CP.NCOMP, integrands.cuba_integrand_brems_2nd_l1k2_2,
-//	          USERDATA, CP.NVEC, CP.EPSREL, CP.EPSABS, CP.flags, CP.SEED,
-//	          CP.MINEVAL, CP.MAXEVAL_2nd, CP.NSTART, CP.NINCREASE, CP.NBATCH,
-//	          CP.GRIDNO_brems_2nd_add_l1k2, CP.STATEFILE, CP.SPIN,
-//	          &CP.neval, &CP.fail, integral, error, prob);
-//
-//	      sigma_2hp_l1k2_2 = integral[CP.comp]*nb;
-//	      error_sigma_2hp_l1k2_2 = error[CP.comp]*nb;
-//
-//	      llVegas(CP.NDIM_brems_2nd, CP.NCOMP, integrands.cuba_integrand_brems_2nd_l2k1_2,
-//	          USERDATA, CP.NVEC, CP.EPSREL, CP.EPSABS, CP.flags, CP.SEED,
-//	          CP.MINEVAL, 1e8, CP.NSTART, CP.NINCREASE, CP.NBATCH,
-//	          CP.GRIDNO_brems_2nd_add_l2k1, CP.STATEFILE, CP.SPIN,
-//	          &CP.neval, &CP.fail, integral, error, prob);
-//
-//	      llVegas(CP.NDIM_brems_2nd, CP.NCOMP, integrands.cuba_integrand_brems_2nd_l2k1_2,
-//	          USERDATA, CP.NVEC, CP.EPSREL, CP.EPSABS, CP.flags, CP.SEED,
-//	          CP.MINEVAL, CP.MAXEVAL_2nd, CP.NSTART, CP.NINCREASE, CP.NBATCH,
-//	          CP.GRIDNO_brems_2nd_add_l2k1, CP.STATEFILE, CP.SPIN,
-//	          &CP.neval, &CP.fail, integral, error, prob);
-//
-//	      sigma_2hp_l2k1_2 = integral[CP.comp]*nb;
-//	      error_sigma_2hp_l2k1_2 = error[CP.comp]*nb;
-
-//	      llVegas(CP.NDIM_brems_2nd, CP.NCOMP, integrands.cuba_integrand_brems_2nd_l2k2_2,
-//	          USERDATA, CP.NVEC, CP.EPSREL, CP.EPSABS, CP.flags, CP.SEED,
-//	          CP.MINEVAL, 1e8, CP.NSTART, CP.NINCREASE, CP.NBATCH,
-//	          CP.GRIDNO_brems_2nd_add_l2k2, CP.STATEFILE, CP.SPIN,
-//	          &CP.neval, &CP.fail, integral, error, prob);
-//
-//	      llVegas(CP.NDIM_brems_2nd, CP.NCOMP, integrands.cuba_integrand_brems_2nd_l2k2_2,
-//	          USERDATA, CP.NVEC, CP.EPSREL, CP.EPSABS, CP.flags, CP.SEED,
-//	          CP.MINEVAL, CP.MAXEVAL_2nd, CP.NSTART, CP.NINCREASE, CP.NBATCH,
-//	          CP.GRIDNO_brems_2nd_add_l2k2, CP.STATEFILE, CP.SPIN,
-//	          &CP.neval, &CP.fail, integral, error, prob);
-//
-//	      sigma_2hp_l2k2_2 = integral[CP.comp]*nb;
-//	      error_sigma_2hp_l2k2_2 = error[CP.comp]*nb;
-	    }
-
-	    if (param.flag[param.int_method] == 1) {
-	    llSuave(CP.NDIM_brems_2nd, CP.NCOMP, integrands.cuba_integrand_brems_2nd_l1k1_1,
-	        USERDATA, CP.NVEC, CP.EPSREL, CP.EPSABS, CP.flags_brems | 4, CP.SEED,
-	        CP.MINEVAL, CP.MAXEVAL_2nd, CP.NNEW, CP.NMIN, CP.FLATNESS,
-	        CP.STATEFILE, CP.SPIN,
-	        &CP.nregions, &CP.neval, &CP.fail, integral, error, prob);
-
-	    sigma_2hp_l1k1_1 = integral[CP.comp]*nb;
-	    error_sigma_2hp_l1k1_1 = error[CP.comp]*nb;
-
-	    llSuave(CP.NDIM_brems_2nd, CP.NCOMP, integrands.cuba_integrand_brems_2nd_l1k2_1,
-	        USERDATA, CP.NVEC, CP.EPSREL, CP.EPSABS, CP.flags_brems | 4, CP.SEED,
-	        CP.MINEVAL, CP.MAXEVAL_2nd, CP.NNEW, CP.NMIN, CP.FLATNESS,
-	        CP.STATEFILE, CP.SPIN,
-	        &CP.nregions, &CP.neval, &CP.fail, integral, error, prob);
-
-	    sigma_2hp_l1k2_1 = integral[CP.comp]*nb;
-	    error_sigma_2hp_l1k2_1 = error[CP.comp]*nb;
-
-	    llSuave(CP.NDIM_brems_2nd, CP.NCOMP, integrands.cuba_integrand_brems_2nd_l2k1_1,
-	        USERDATA, CP.NVEC, CP.EPSREL, CP.EPSABS, CP.flags_brems | 4, CP.SEED,
-	        CP.MINEVAL, CP.MAXEVAL_2nd, CP.NNEW, CP.NMIN, CP.FLATNESS,
-	        CP.STATEFILE, CP.SPIN,
-	        &CP.nregions, &CP.neval, &CP.fail, integral, error, prob);
-
-	    sigma_2hp_l2k1_1 = integral[CP.comp]*nb;
-	    error_sigma_2hp_l2k1_1 = error[CP.comp]*nb;
-
-	    llSuave(CP.NDIM_brems_2nd, CP.NCOMP, integrands.cuba_integrand_brems_2nd_l2k2_1,
-	        USERDATA, CP.NVEC, CP.EPSREL, CP.EPSABS, CP.flags_brems | 4, CP.SEED,
-	        CP.MINEVAL, CP.MAXEVAL_2nd, CP.NNEW, CP.NMIN, CP.FLATNESS,
-	        CP.STATEFILE, CP.SPIN,
-	        &CP.nregions, &CP.neval, &CP.fail, integral, error, prob);
-
-	    sigma_2hp_l2k2_1 = integral[CP.comp]*nb;
-	    error_sigma_2hp_l2k2_1 = error[CP.comp]*nb;
-
-	    llSuave(CP.NDIM_brems_2nd, CP.NCOMP, integrands.cuba_integrand_brems_2nd_l1k1_2,
-	        USERDATA, CP.NVEC, CP.EPSREL, CP.EPSABS, CP.flags_brems | 4, CP.SEED,
-	        CP.MINEVAL, CP.MAXEVAL_2nd, CP.NNEW, CP.NMIN, CP.FLATNESS,
-	        CP.STATEFILE, CP.SPIN,
-	        &CP.nregions, &CP.neval, &CP.fail, integral, error, prob);
-
-	    sigma_2hp_l1k1_2 = integral[CP.comp]*nb;
-	    error_sigma_2hp_l1k1_2 = error[CP.comp]*nb;
-
-	    llSuave(CP.NDIM_brems_2nd, CP.NCOMP, integrands.cuba_integrand_brems_2nd_l1k2_2,
-	        USERDATA, CP.NVEC, CP.EPSREL, CP.EPSABS, CP.flags_brems | 4, CP.SEED,
-	        CP.MINEVAL, CP.MAXEVAL_2nd, CP.NNEW, CP.NMIN, CP.FLATNESS,
-	        CP.STATEFILE, CP.SPIN,
-	        &CP.nregions, &CP.neval, &CP.fail, integral, error, prob);
-
-	    sigma_2hp_l1k2_2 = integral[CP.comp]*nb;
-	    error_sigma_2hp_l1k2_2 = error[CP.comp]*nb;
-
-	    llSuave(CP.NDIM_brems_2nd, CP.NCOMP, integrands.cuba_integrand_brems_2nd_l2k1_2,
-	        USERDATA, CP.NVEC, CP.EPSREL, CP.EPSABS, CP.flags_brems | 4, CP.SEED,
-	        CP.MINEVAL, CP.MAXEVAL_2nd, CP.NNEW, CP.NMIN, CP.FLATNESS,
-	        CP.STATEFILE, CP.SPIN,
-	        &CP.nregions, &CP.neval, &CP.fail, integral, error, prob);
-
-	    sigma_2hp_l2k1_2 = integral[CP.comp]*nb;
-	    error_sigma_2hp_l2k1_2 = error[CP.comp]*nb;
-
-	    llSuave(CP.NDIM_brems_2nd, CP.NCOMP, integrands.cuba_integrand_brems_2nd_l2k2_2,
-	        USERDATA, CP.NVEC, CP.EPSREL, CP.EPSABS, CP.flags_brems | 4, CP.SEED,
-	        CP.MINEVAL, CP.MAXEVAL_2nd, CP.NNEW, CP.NMIN, CP.FLATNESS,
-	        CP.STATEFILE, CP.SPIN,
-	        &CP.nregions, &CP.neval, &CP.fail, integral, error, prob);
-
-	    sigma_2hp_l2k2_2 = integral[CP.comp]*nb;
-	    error_sigma_2hp_l2k2_2 = error[CP.comp]*nb;
-	  }
-	    std::cout << sigma_2hp_l1k1_1 <<" +- "<< error_sigma_2hp_l1k1_1 <<"\n";
-	    std::cout << sigma_2hp_l1k2_1 <<" +- "<< error_sigma_2hp_l1k2_1 <<"\n";
-	    std::cout << sigma_2hp_l2k1_1 <<" +- "<< error_sigma_2hp_l2k1_1 <<"\n";
-	    std::cout << sigma_2hp_l2k2_1 <<" +- "<< error_sigma_2hp_l2k2_1 <<"\n";
-	    std::cout << sigma_2hp_l1k1_2 <<" +- "<< error_sigma_2hp_l1k1_2 <<"\n";
-	    std::cout << sigma_2hp_l1k2_2 <<" +- "<< error_sigma_2hp_l1k2_2 <<"\n";
-	    std::cout << sigma_2hp_l2k1_2 <<" +- "<< error_sigma_2hp_l2k1_2 <<"\n";
-	    std::cout << sigma_2hp_l2k2_2 <<" +- "<< error_sigma_2hp_l2k2_2 <<"\n";
-
-	    double sigma_2hp_l1k1 = sigma_2hp_l1k1_1 + sigma_2hp_l1k1_2;
-	    double sigma_2hp_l1k1_error = sqrt(pow(error_sigma_2hp_l1k1_1,2.)+pow(error_sigma_2hp_l1k1_2,2.));
-	    double sigma_2hp_l1k2 = sigma_2hp_l1k2_1 + sigma_2hp_l1k2_2;
-	    double sigma_2hp_l1k2_error = sqrt(pow(error_sigma_2hp_l1k2_1,2.)+pow(error_sigma_2hp_l1k2_2,2.));
-	    double sigma_2hp_l2k1 = sigma_2hp_l2k1_1 + sigma_2hp_l2k1_2;
-	    double sigma_2hp_l2k1_error = sqrt(pow(error_sigma_2hp_l2k1_1,2.)+pow(error_sigma_2hp_l2k1_2,2.));
-	    double sigma_2hp_l2k2 = sigma_2hp_l2k2_1 + sigma_2hp_l2k2_2;
-	    double sigma_2hp_l2k2_error = sqrt(pow(error_sigma_2hp_l2k2_1,2.)+pow(error_sigma_2hp_l2k2_2,2.));
-
-//	    double sigma_2hp_l1k1 = sigma_2hp_l1k1_2;
-//	    double sigma_2hp_l1k1_error = error_sigma_2hp_l1k1_2;
-//	    double sigma_2hp_l1k2 = sigma_2hp_l1k2_2;
-//	    double sigma_2hp_l1k2_error = error_sigma_2hp_l1k2_2;
-//	    double sigma_2hp_l2k1 = sigma_2hp_l2k1_2;
-//	    double sigma_2hp_l2k1_error = error_sigma_2hp_l2k1_2;
-//	    double sigma_2hp_l2k2 = sigma_2hp_l2k2_2;
-//	    double sigma_2hp_l2k2_error = error_sigma_2hp_l2k2_2;
-
-	    output.sigma_unpol_inelastic_2nd = sigma_2hp_l1k1 + sigma_2hp_l1k2 + sigma_2hp_l2k1 + sigma_2hp_l2k2;
-	    errors.sigma_unpol_inelastic_2nd = sqrt(pow(sigma_2hp_l1k1_error,2.) + pow(sigma_2hp_l1k2_error,2.)
-	                  + pow(sigma_2hp_l2k1_error,2.) + pow(sigma_2hp_l2k2_error,2.));
-	}
-
-	if (param.flag[param.asymmetry] == 1 && param.flag[param.brems] == 12) {
-
-		llSuave(CP.NDIM_brems_2nd, CP.NCOMP, integrands.cuba_integrand_brems_2nd_pol_add,
-				USERDATA, CP.NVEC, CP.EPSREL, CP.EPSABS, CP.flags_brems | 4, CP.SEED,
-				CP.MINEVAL, CP.MAXEVAL_2nd_add, CP.NNEW, CP.NMIN, CP.FLATNESS,
-				CP.STATEFILE, CP.SPIN,
-				&CP.nregions, &CP.neval, &CP.fail, integral, error, prob);
-
-		output.sigma_pol_2nd_add = param.P*integral[CP.comp]*nb;
-		errors.sigma_pol_2nd_add = param.P*error[CP.comp]*nb;
-	}
-
-	if (param.flag[param.asymmetry] == 1 && (param.flag[param.brems] == 1 || param.flag[param.brems] == 2)) {
-
-		std::cout << "Numerical integration for one hard-photon polarized cross-section ... ";
-
-		if (param.flag[param.int_method] == 0) {
-			llVegas(CP.NDIM_brems_1st, CP.NCOMP, integrands.cuba_integrand_interf_brems_1st,
-					USERDATA, CP.NVEC, CP.EPSREL, CP.EPSABS, CP.flags, CP.SEED,
-					CP.MINEVAL, 1e7, CP.NSTART, CP.NINCREASE, CP.NBATCH,
-					CP.GRIDNO_brems_interf, CP.STATEFILE, CP.SPIN,
-					&CP.neval, &CP.fail, integral, error, prob);
-
-			llVegas(CP.NDIM_brems_1st, CP.NCOMP, integrands.cuba_integrand_interf_brems_1st,
-					USERDATA, CP.NVEC, CP.EPSREL, CP.EPSABS, CP.flags, CP.SEED,
-					CP.MINEVAL, CP.MAXEVAL_1st, CP.NSTART, CP.NINCREASE, CP.NBATCH,
-					CP.GRIDNO_brems_interf, CP.STATEFILE, CP.SPIN,
-					&CP.neval, &CP.fail, integral, error, prob);
-		}
-
-		if (param.flag[param.int_method] == 1) {
-			llSuave(CP.NDIM_brems_1st, CP.NCOMP, integrands.cuba_integrand_interf_brems_1st,
-					USERDATA, CP.NVEC, CP.EPSREL, CP.EPSABS, CP.flags_brems | 4, CP.SEED,
-					CP.MINEVAL, CP.MAXEVAL_1st, CP.NNEW, CP.NMIN, CP.FLATNESS,
-					CP.STATEFILE, CP.SPIN,
-					&CP.nregions, &CP.neval, &CP.fail, integral, error, prob);
-		}
-
-		if (param.flag[param.int_method] == 2) {
-			llCuhre(CP.NDIM_brems_1st, CP.NCOMP, integrands.cuba_integrand_interf_brems_1st,
-					USERDATA, CP.NVEC, CP.EPSREL, CP.EPSABS, CP.flags_brems | 4,
-					CP.MINEVAL, CP.MAXEVAL_1st, 9,
-					CP.STATEFILE, CP.SPIN,
-					&CP.nregions, &CP.neval, &CP.fail, integral, error, prob);
-		}
-
-		if (param.flag[param.order] == 1) {
-			output.sigma_pol_inelastic_1st = param.P*integral[CP.comp]*nb;
-			errors.sigma_pol_inelastic_1st = param.P*error[CP.comp]*nb;
-			output.sigma_pol_1st = output.sigma_pol_inelastic_1st + output.sigma_pol_elastic_1st;
-			errors.sigma_pol_1st = errors.sigma_pol_inelastic_1st + errors.sigma_pol_elastic_1st;
-			output.asymm_1st = output.sigma_pol_1st / output.sigma_unpol_1st;
-			errors.asymm_1st = output.asymm_1st * sqrt(pow(errors.sigma_pol_1st / output.sigma_pol_1st, 2.)
-					+ pow(errors.sigma_unpol_1st / output.sigma_unpol_1st, 2.));
-			output.rel_asymm_1st = - 100.*(output.asymm_1st - output.asymm_born) / output.asymm_born;
-			output.sigma_1st = output.sigma_pol_1st + output.sigma_unpol_1st;
-			errors.sigma_1st = sqrt(pow(output.sigma_pol_1st,2.)
-												+ pow(output.sigma_unpol_1st,2.));
-		}
-		if (param.flag[param.order] == 2) {
-			output.sigma_pol_inelastic_loop = param.P*integral[CP.comp]*nb;
-			errors.sigma_pol_inelastic_loop = param.P*error[CP.comp]*nb;
-		}
-		std::cout << "completed\n";
-
-		if (param.flag[param.order] == 2 && param.flag[param.brems_add] == 1) {
-
-			std::cout << "Numerical integration for one hard-photon and one soft-photon finite contribution ... ";
-
-			llSuave(CP.NDIM_brems_2nd, CP.NCOMP, integrands.cuba_integrand_brems_2nd_pol_add,
-					USERDATA, CP.NVEC, CP.EPSREL, CP.EPSABS, CP.flags_brems | 4, CP.SEED,
-					CP.MINEVAL, CP.MAXEVAL_2nd_add, CP.NNEW, CP.NMIN, CP.FLATNESS,
-					CP.STATEFILE, CP.SPIN,
-					&CP.nregions, &CP.neval, &CP.fail, integral, error, prob);
-
-			output.sigma_pol_2nd_add = param.P*integral[CP.comp]*nb;
-			errors.sigma_pol_2nd_add = param.P*error[CP.comp]*nb;
-			output.sigma_pol_inelastic_loop += output.sigma_pol_2nd_add;
-			errors.sigma_pol_inelastic_loop = sqrt(pow(errors.sigma_pol_2nd_add,2.)
-													+ pow(errors.sigma_pol_inelastic_loop,2.));
-
-			std::cout <<"completed\n";
-
-		}
-	}
-
-	if (param.flag[param.asymmetry] == 1 && (param.flag[param.brems] == 2 || param.flag[param.brems] == 3)) {
-
-		std::cout << "Numerical integration for two hard-photons polarized cross-section ... ";
-
+// Two-photon bremsstrahlung for the polarized cross section 
+	if (param.flag[param.asymmetry] == 1 && 
+        (param.flag[param.brems] == 2 || 
+         param.flag[param.brems] == 3)) {
+		std::cout << "Integration for two hard photon polarized cross section ... ";
 		double sigma_pol_2hg_1, error_sigma_pol_2hg_1, sigma_pol_2hg_2, error_sigma_pol_2hg_2;
-
 		if (param.flag[param.int_method] == 0) {
-
 			llVegas(CP.NDIM_brems_2nd, CP.NCOMP, integrands.cuba_integrand_interf_brems_2nd_1,
 					USERDATA, CP.NVEC, CP.EPSREL, CP.EPSABS, CP.flags, CP.SEED,
 					CP.MINEVAL, 1e8, CP.NSTART, CP.NINCREASE, CP.NBATCH,
 					CP.GRIDNO_brems_interf_2nd_1, CP.STATEFILE, CP.SPIN,
 					&CP.neval, &CP.fail, integral, error, prob);
-
 			llVegas(CP.NDIM_brems_2nd, CP.NCOMP, integrands.cuba_integrand_interf_brems_2nd_1,
 					USERDATA, CP.NVEC, CP.EPSREL, CP.EPSABS, CP.flags_brems, CP.SEED,
 					CP.MINEVAL, CP.MAXEVAL_2nd, CP.NSTART, CP.NINCREASE, CP.NBATCH,
 					CP.GRIDNO_brems_interf_2nd_1, CP.STATEFILE, CP.SPIN,
 					&CP.neval, &CP.fail, integral, error, prob);
-
 			sigma_pol_2hg_1 = integral[CP.comp]*nb;
 			error_sigma_pol_2hg_1 = error[CP.comp]*nb;
-
 			llVegas(CP.NDIM_brems_2nd, CP.NCOMP, integrands.cuba_integrand_interf_brems_2nd_2,
 					USERDATA, CP.NVEC, CP.EPSREL, CP.EPSABS, CP.flags, CP.SEED,
 					CP.MINEVAL, 1e8, CP.NSTART, CP.NINCREASE, CP.NBATCH,
 					CP.GRIDNO_brems_interf_2nd_2, CP.STATEFILE, CP.SPIN,
 					&CP.neval, &CP.fail, integral, error, prob);
-
 			llVegas(CP.NDIM_brems_2nd, CP.NCOMP, integrands.cuba_integrand_interf_brems_2nd_2,
 					USERDATA, CP.NVEC, CP.EPSREL, CP.EPSABS, CP.flags_brems, CP.SEED,
 					CP.MINEVAL, CP.MAXEVAL_2nd, CP.NSTART, CP.NINCREASE, CP.NBATCH,
 					CP.GRIDNO_brems_interf_2nd_2, CP.STATEFILE, CP.SPIN,
 					&CP.neval, &CP.fail, integral, error, prob);
-
 			sigma_pol_2hg_2 = integral[CP.comp]*nb;
 			error_sigma_pol_2hg_2 = error[CP.comp]*nb;
 		}
-
 		if (param.flag[param.int_method] == 1) {
-
 			llSuave(CP.NDIM_brems_2nd, CP.NCOMP, integrands.cuba_integrand_interf_brems_2nd_1,
 					USERDATA, CP.NVEC, CP.EPSREL, CP.EPSABS, CP.flags_brems | 4, CP.SEED,
 					CP.MINEVAL, CP.MAXEVAL_2nd, CP.NNEW, CP.NMIN, CP.FLATNESS,
 					CP.STATEFILE, CP.SPIN,
 					&CP.nregions, &CP.neval, &CP.fail, integral, error, prob);
-
 			sigma_pol_2hg_1 = integral[CP.comp]*nb;
 			error_sigma_pol_2hg_1 = error[CP.comp]*nb;
-
 			llSuave(CP.NDIM_brems_2nd, CP.NCOMP, integrands.cuba_integrand_interf_brems_2nd_2,
 					USERDATA, CP.NVEC, CP.EPSREL, CP.EPSABS, CP.flags_brems | 4, CP.SEED,
 					CP.MINEVAL, CP.MAXEVAL_2nd, CP.NNEW, CP.NMIN, CP.FLATNESS,
 					CP.STATEFILE, CP.SPIN,
 					&CP.nregions, &CP.neval, &CP.fail, integral, error, prob);
-
 			sigma_pol_2hg_2 = integral[CP.comp]*nb;
 			error_sigma_pol_2hg_2 = error[CP.comp]*nb;
 		}
-
 		if (param.flag[param.int_method] == 2) {
-
 			llCuhre(CP.NDIM_brems_2nd, CP.NCOMP, integrands.cuba_integrand_interf_brems_2nd_1,
 					USERDATA, CP.NVEC, CP.EPSREL, CP.EPSABS, CP.flags_brems | 4,
 					CP.MINEVAL, CP.MAXEVAL_2nd, CP.KEY,
 					CP.STATEFILE, CP.SPIN,
 					&CP.nregions, &CP.neval, &CP.fail, integral, error, prob);
-
 			sigma_pol_2hg_1 = integral[CP.comp]*nb;
 			error_sigma_pol_2hg_1 = error[CP.comp]*nb;
-
 			llCuhre(CP.NDIM_brems_2nd, CP.NCOMP, integrands.cuba_integrand_interf_brems_2nd_2,
 					USERDATA, CP.NVEC, CP.EPSREL, CP.EPSABS, CP.flags_brems | 4,
 					CP.MINEVAL, CP.MAXEVAL_2nd, CP.KEY,
 					CP.STATEFILE, CP.SPIN,
 					&CP.nregions, &CP.neval, &CP.fail, integral, error, prob);
-
 			sigma_pol_2hg_2 = integral[CP.comp]*nb;
 			error_sigma_pol_2hg_2 = error[CP.comp]*nb;
 		}
-
 		output.sigma_pol_inelastic_2nd = param.P*(sigma_pol_2hg_1 + sigma_pol_2hg_2);
-		errors.sigma_pol_inelastic_2nd = param.P*sqrt(pow(error_sigma_pol_2hg_1,2.)
-													+ pow(error_sigma_pol_2hg_2,2.));
+		errors.sigma_pol_inelastic_2nd = param.P*sqrt(pow(error_sigma_pol_2hg_1,2.) + 
+                                                      pow(error_sigma_pol_2hg_2,2.));
 		if (param.flag[param.order] == 2) {
-			output.sigma_pol_2nd = output.sigma_pol_elastic_2nd + output.sigma_pol_inelastic_loop + output.sigma_pol_inelastic_2nd;
+			output.sigma_pol_2nd = output.sigma_pol_elastic_2nd + 
+                                   output.sigma_pol_inelastic_loop + 
+                                   output.sigma_pol_inelastic_2nd;
 			errors.sigma_pol_2nd = sqrt(pow(errors.sigma_pol_elastic_2nd,2.) +
-					pow(errors.sigma_pol_inelastic_loop,2.) + pow(errors.sigma_pol_inelastic_2nd,2.));
+                                        pow(errors.sigma_pol_inelastic_loop,2.) + 
+                                        pow(errors.sigma_pol_inelastic_2nd,2.));
 			output.asymm_2nd = output.sigma_pol_2nd / output.sigma_unpol_2nd;
-			errors.asymm_2nd = output.asymm_2nd * sqrt(pow(errors.sigma_pol_2nd / output.sigma_pol_2nd, 2.)
-					+ pow(errors.sigma_unpol_2nd / output.sigma_unpol_2nd, 2.));
-			output.rel_asymm_2nd = - 100.*(output.asymm_2nd - output.asymm_born) / output.asymm_born;
-			errors.sigma_2nd = sqrt(pow(output.sigma_pol_2nd,2.)
-												+ pow(output.sigma_unpol_2nd,2.));
+			errors.asymm_2nd = abs(output.asymm_2nd) * 
+                               sqrt(pow(errors.sigma_pol_2nd / output.sigma_pol_2nd, 2.) + 
+                                    pow(errors.sigma_unpol_2nd / output.sigma_unpol_2nd, 2.));
+			output.rel_asymm_2nd = - 100.*(output.asymm_2nd - output.asymm_born) / 
+                                         output.asymm_born;
+			errors.sigma_2nd = sqrt(pow(output.sigma_pol_2nd,2.) + 
+                                    pow(output.sigma_unpol_2nd,2.));
 			output.sigma_2nd = output.sigma_pol_2nd + output.sigma_unpol_2nd;
-			errors.sigma_2nd = sqrt(pow(output.sigma_pol_2nd,2.)
-												+ pow(output.sigma_unpol_2nd,2.));
+			errors.sigma_2nd = sqrt(pow(output.sigma_pol_2nd,2.) + 
+                                    pow(output.sigma_unpol_2nd,2.));
 		}
 		std::cout << "completed\n";
 	}
+// End section for two-photon bremsstrahlung for polarized cross section 
 
+
+// To keep track of 1st-order results if 2nd order was requested: 
+// Recalculate one-photon bremsstrahlung without loop+soft-photon
 	if (param.flag[param.brems] == 2 && param.flag[param.order] == 2) {
-
-		param.flag[param.order] = 1;
-		CP.MAXEVAL_1st = param.maxeval_1st_aux;
-
+        param.flag[param.order] = 1;
+		param.MAXEVAL_1st = param.maxeval_1st_aux;
 		llVegas(CP.NDIM_ELASTIC, CP.NCOMP, integrands.cuba_integrand_elastic,
 				USERDATA, CP.NVEC, CP.EPSREL, CP.EPSABS, CP.flags, CP.SEED,
-				CP.MINEVAL, CP.MAXEVAL_LO, CP.NSTART, CP.NINCREASE, CP.NBATCH,
+				CP.MINEVAL, 1e7, CP.NSTART, CP.NINCREASE, CP.NBATCH,
 				CP.GRIDNO, CP.STATEFILE, CP.SPIN,
 				&CP.neval, &CP.fail, integral, error, prob);
-
-		errors.sigma_unpol_elastic_1st = error[CP.comp]*nb;
-		output.sigma_unpol_elastic_1st = integral[CP.comp]*nb;
-
+        output.sigma_unpol_elastic_1st = integral[CP.comp]*nb;
+        errors.sigma_unpol_elastic_1st = error[CP.comp]*nb;
 		if (param.flag[param.int_method] == 0) {
 			if (param.flag[param.PS] == 0) {
 				llVegas(CP.NDIM_brems_1st, CP.NCOMP, integrands.cuba_integrand_brems_1st,
 						USERDATA, CP.NVEC, CP.EPSREL, CP.EPSABS, CP.flags, CP.SEED,
 						CP.MINEVAL, 1e7, CP.NSTART, CP.NINCREASE, CP.NBATCH,
-						CP.GRIDNO_brems, CP.STATEFILE, CP.SPIN,
+						CP.GRIDNO_brems_1st, CP.STATEFILE, CP.SPIN,
 						&CP.neval, &CP.fail, integral, error, prob);
-
 				llVegas(CP.NDIM_brems_1st, CP.NCOMP, integrands.cuba_integrand_brems_1st,
 						USERDATA, CP.NVEC, CP.EPSREL, CP.EPSABS, CP.flags_brems, CP.SEED,
 						CP.MINEVAL, CP.MAXEVAL_1st, CP.NSTART, CP.NINCREASE, CP.NBATCH,
-						CP.GRIDNO_brems, CP.STATEFILE, CP.SPIN,
+						CP.GRIDNO_brems_1st, CP.STATEFILE, CP.SPIN,
 						&CP.neval, &CP.fail, integral, error, prob);
 			}
 			if (param.flag[param.PS] == 1) {
 				llVegas(CP.NDIM_brems_1st, CP.NCOMP, integrands.cuba_integrand_brems_1st_ps2,
 						USERDATA, CP.NVEC, CP.EPSREL, CP.EPSABS, CP.flags, CP.SEED,
 						CP.MINEVAL, 1e7, CP.NSTART, CP.NINCREASE, CP.NBATCH,
-						CP.GRIDNO_brems, CP.STATEFILE, CP.SPIN,
+						CP.GRIDNO_brems_1st, CP.STATEFILE, CP.SPIN,
 						&CP.neval, &CP.fail, integral, error, prob);
-
 				llVegas(CP.NDIM_brems_1st, CP.NCOMP, integrands.cuba_integrand_brems_1st_ps2,
 						USERDATA, CP.NVEC, CP.EPSREL, CP.EPSABS, CP.flags_brems, CP.SEED,
 						CP.MINEVAL, CP.MAXEVAL_1st, CP.NSTART, CP.NINCREASE, CP.NBATCH,
-						CP.GRIDNO_brems, CP.STATEFILE, CP.SPIN,
+						CP.GRIDNO_brems_1st, CP.STATEFILE, CP.SPIN,
 						&CP.neval, &CP.fail, integral, error, prob);
 			}
 		}
-
-		if (param.flag[param.int_method] == 1) {
+        if (param.flag[param.int_method] == 1) {
 			if (param.flag[param.PS] == 0) {
 				llSuave(CP.NDIM_brems_1st, CP.NCOMP, integrands.cuba_integrand_brems_1st,
 						USERDATA, CP.NVEC, CP.EPSREL, CP.EPSABS, CP.flags_brems | 4, CP.SEED,
@@ -1777,7 +1163,6 @@ int PES::initialization(){
 						CP.STATEFILE, CP.SPIN,
 						&CP.nregions, &CP.neval, &CP.fail, integral, error, prob);
 			}
-
 			if (param.flag[param.PS] == 1) {
 				llSuave(CP.NDIM_brems_1st, CP.NCOMP, integrands.cuba_integrand_brems_1st_ps2,
 						USERDATA, CP.NVEC, CP.EPSREL, CP.EPSABS, CP.flags_brems | 4, CP.SEED,
@@ -1785,45 +1170,57 @@ int PES::initialization(){
 						CP.STATEFILE, CP.SPIN,
 						&CP.nregions, &CP.neval, &CP.fail, integral, error, prob);
 			}
-    }
-
+        }
 		output.sigma_unpol_inelastic_1st = integral[CP.comp]*nb;
 		errors.sigma_unpol_inelastic_1st = error[CP.comp]*nb;
-		output.sigma_unpol_1st = output.sigma_unpol_inelastic_1st + output.sigma_unpol_elastic_1st;
+        output.sigma_unpol_1st = output.sigma_unpol_inelastic_1st + output.sigma_unpol_elastic_1st;
 		errors.sigma_unpol_1st = errors.sigma_unpol_inelastic_1st + errors.sigma_unpol_elastic_1st;
+// add hadronic contribution if non-zero
+        output.sigma_unpol_inelastic_1st += output.sigma_unpol_inelastic_1st_hadr_interf;
+        errors.sigma_unpol_inelastic_1st = sqrt(pow(errors.sigma_unpol_inelastic_1st,2.) + 
+                                            pow(errors.sigma_unpol_inelastic_1st_hadr_interf,2.));
+        output.sigma_unpol_1st += output.sigma_unpol_inelastic_1st_hadr_interf;
+        errors.sigma_unpol_1st = sqrt(pow(errors.sigma_unpol_1st,2.) + 
+                                      pow(errors.sigma_unpol_inelastic_1st_hadr_interf,2.));
+        output.sigma_unpol_inelastic_1st += output.sigma_unpol_inelastic_1st_hadr;
+        errors.sigma_unpol_inelastic_1st = sqrt(pow(errors.sigma_unpol_inelastic_1st,2.) + 
+                                            pow(errors.sigma_unpol_inelastic_1st_hadr,2.));
+        output.sigma_unpol_1st += output.sigma_unpol_inelastic_1st_hadr;
+        errors.sigma_unpol_1st = sqrt(pow(errors.sigma_unpol_1st,2.) + 
+                                      pow(errors.sigma_unpol_inelastic_1st_hadr,2.));
 
-		if (param.flag[param.asymmetry] == 1) {
-
+        if (param.flag[param.asymmetry] == 1) {
 			llVegas(CP.NDIM_ELASTIC, CP.NCOMP, integrands.cuba_integrand_interf_elastic,
 					USERDATA, CP.NVEC, CP.EPSREL, CP.EPSABS, CP.flags, CP.SEED,
 					CP.MINEVAL, 1e8, CP.NSTART, CP.NINCREASE, CP.NBATCH,
 					CP.GRIDNO, CP.STATEFILE, CP.SPIN,
 					&CP.neval, &CP.fail, integral, error, prob);
-
-			errors.sigma_pol_elastic_1st = param.P*error[CP.comp]*nb;
 			output.sigma_pol_elastic_1st = param.P*integral[CP.comp]*nb;
-
+            errors.sigma_pol_elastic_1st = param.P*error[CP.comp]*nb;
 			llVegas(CP.NDIM_brems_1st, CP.NCOMP, integrands.cuba_integrand_interf_brems_1st,
 					USERDATA, CP.NVEC, CP.EPSREL, CP.EPSABS, CP.flags, CP.SEED,
 					CP.MINEVAL, CP.MAXEVAL_1st, CP.NSTART, CP.NINCREASE, CP.NBATCH,
 					CP.GRIDNO_brems_interf, CP.STATEFILE, CP.SPIN,
 					&CP.neval, &CP.fail, integral, error, prob);
-
 			output.sigma_pol_inelastic_1st = param.P*integral[CP.comp]*nb;
 			errors.sigma_pol_inelastic_1st = param.P*error[CP.comp]*nb;
 			output.sigma_pol_1st = output.sigma_pol_inelastic_1st + output.sigma_pol_elastic_1st;
 			errors.sigma_pol_1st = errors.sigma_pol_inelastic_1st + errors.sigma_pol_elastic_1st;
 			output.asymm_1st = output.sigma_pol_1st / output.sigma_unpol_1st;
-			errors.asymm_1st = output.asymm_1st * sqrt(pow(errors.sigma_pol_1st / output.sigma_pol_1st, 2.)
-					+ pow(errors.sigma_unpol_1st / output.sigma_unpol_1st, 2.));
+			errors.asymm_1st = abs(output.asymm_1st) * 
+                               sqrt(pow(errors.sigma_pol_1st / output.sigma_pol_1st, 2.) + 
+                                    pow(errors.sigma_unpol_1st / output.sigma_unpol_1st, 2.));
 			output.sigma_1st = output.sigma_pol_1st + output.sigma_unpol_1st;
-			errors.sigma_1st = sqrt(pow(output.sigma_pol_1st,2.)
-												+ pow(output.sigma_unpol_1st,2.));
+			errors.sigma_1st = sqrt(pow(output.sigma_pol_1st,2.) + 
+                                    pow(output.sigma_unpol_1st,2.));
 		}
 		param.flag[param.order] = 2;
 		param.MAXEVAL_1st = param.MAXEVAL_gamma_loop;
 	}
+// End section to repeat one-photon bremsstrahlung at 1st order 
 
+        
+// param.en <= 10 ?
 	if (param.en <= 10.) {
 		if (param.flag[param.brems] == 0) {
 			output.sigma_unpol_1st_vect.push_back(output.sigma_unpol_1st);
@@ -1835,7 +1232,8 @@ int PES::initialization(){
 			}
 		}
 		if (param.flag[param.brems] == 1) {
-			output.ev_brems_1st.push_back(output.sigma_unpol_inelastic_1st / output.sigma_unpol_1st);
+			output.ev_brems_1st.push_back(output.sigma_unpol_inelastic_1st / 
+                                          output.sigma_unpol_1st);
 			output.sigma_unpol_1st_vect.push_back(output.sigma_unpol_1st);
 			output.sigma_unpol_1st_elastic_vect.push_back(output.sigma_unpol_elastic_1st);
 			output.sigma_unpol_1st_inelastic_vect.push_back(output.sigma_unpol_inelastic_1st);
@@ -1845,13 +1243,19 @@ int PES::initialization(){
 			}
 		}
 		if (param.flag[param.brems] == 2) {
-			output.ev_brems_1st.push_back(output.sigma_unpol_inelastic_1st / output.sigma_unpol_2nd);
+			output.ev_brems_1st.push_back(output.sigma_unpol_inelastic_1st / 
+                                          output.sigma_unpol_2nd);
 			output.sigma_unpol_1st_vect.push_back(output.sigma_unpol_1st);
-			output.ev_brems_2nd.push_back(output.sigma_unpol_inelastic_2nd / output.sigma_unpol_2nd);
-			output.ev_brems_2nd_l1k1.push_back(sigma_hp_2nd_l1k1 / output.sigma_unpol_inelastic_2nd);
-			output.ev_brems_2nd_l1k2.push_back(sigma_hp_2nd_l1k2 / output.sigma_unpol_inelastic_2nd);
-			output.ev_brems_2nd_l2k1.push_back(sigma_hp_2nd_l2k1 / output.sigma_unpol_inelastic_2nd);
-			output.ev_brems_2nd_l2k2.push_back(sigma_hp_2nd_l2k2 / output.sigma_unpol_inelastic_2nd);
+			output.ev_brems_2nd.push_back(output.sigma_unpol_inelastic_2nd / 
+                                          output.sigma_unpol_2nd);
+			output.ev_brems_2nd_l1k1.push_back(sigma_hp_2nd_l1k1 / 
+                                               output.sigma_unpol_inelastic_2nd);
+			output.ev_brems_2nd_l1k2.push_back(sigma_hp_2nd_l1k2 / 
+                                               output.sigma_unpol_inelastic_2nd);
+			output.ev_brems_2nd_l2k1.push_back(sigma_hp_2nd_l2k1 / 
+                                               output.sigma_unpol_inelastic_2nd);
+			output.ev_brems_2nd_l2k2.push_back(sigma_hp_2nd_l2k2 / 
+                                               output.sigma_unpol_inelastic_2nd);
 			output.sigma_unpol_2nd_vect.push_back(output.sigma_unpol_2nd);
 			if (param.flag[param.asymmetry] == 1) {
 				output.sigma_pol_1st_vect.push_back(output.sigma_pol_1st);
@@ -1861,11 +1265,16 @@ int PES::initialization(){
 			}
 		}
 		if (param.flag[param.brems] == 3) {
-			output.ev_brems_2nd.push_back(output.sigma_unpol_inelastic_2nd / output.sigma_unpol_2nd);
-			output.ev_brems_2nd_l1k1.push_back(sigma_hp_2nd_l1k1 / output.sigma_unpol_inelastic_2nd);
-			output.ev_brems_2nd_l1k2.push_back(sigma_hp_2nd_l1k2 / output.sigma_unpol_inelastic_2nd);
-			output.ev_brems_2nd_l2k1.push_back(sigma_hp_2nd_l2k1 / output.sigma_unpol_inelastic_2nd);
-			output.ev_brems_2nd_l2k2.push_back(sigma_hp_2nd_l2k2 / output.sigma_unpol_inelastic_2nd);
+			output.ev_brems_2nd.push_back(output.sigma_unpol_inelastic_2nd / 
+                                          output.sigma_unpol_2nd);
+			output.ev_brems_2nd_l1k1.push_back(sigma_hp_2nd_l1k1 / 
+                                               output.sigma_unpol_inelastic_2nd);
+			output.ev_brems_2nd_l1k2.push_back(sigma_hp_2nd_l1k2 / 
+                                               output.sigma_unpol_inelastic_2nd);
+			output.ev_brems_2nd_l2k1.push_back(sigma_hp_2nd_l2k1 / 
+                                               output.sigma_unpol_inelastic_2nd);
+			output.ev_brems_2nd_l2k2.push_back(sigma_hp_2nd_l2k2 / 
+                                               output.sigma_unpol_inelastic_2nd);
 			output.sigma_unpol_2nd_vect.push_back(output.sigma_unpol_2nd);
 			if (param.flag[param.asymmetry] == 1) {
 				output.sigma_pol_2nd_vect.push_back(output.sigma_pol_2nd);
@@ -1873,8 +1282,11 @@ int PES::initialization(){
 			}
 		}
 	}
+// End section (param.en <= 10.)
 	}
 
+
+// Carbon target 
 	if (param.flag[param.target] == 1) {
 
 		if (param.flag[param.LO] == 1) {
@@ -1928,7 +1340,7 @@ int PES::initialization(){
 				output.sigma_pol_born = param.P*integral[CP.comp]*nb;
 				errors.sigma_pol_born = param.P*error[CP.comp]*nb;
 				output.asymm_born = output.sigma_pol_born / output.sigma_unpol_born;
-				errors.asymm_born = (output.sigma_pol_born/output.sigma_unpol_born) *
+				errors.asymm_born = abs(output.sigma_pol_born/output.sigma_unpol_born) *
 						sqrt(pow(errors.sigma_unpol_born/output.sigma_unpol_born,2.)
 								+ pow(errors.sigma_pol_born/output.sigma_pol_born,2.));
 				output.sigma_born = output.sigma_pol_born + output.sigma_unpol_born;
@@ -2031,7 +1443,7 @@ int PES::initialization(){
 				output.sigma_pol_1st = output.sigma_pol_inelastic_1st + output.sigma_pol_elastic_1st;
 				errors.sigma_pol_1st = errors.sigma_pol_inelastic_1st + errors.sigma_pol_elastic_1st;
 				output.asymm_1st = output.sigma_pol_1st / output.sigma_unpol_1st;
-				errors.asymm_1st = output.asymm_1st * sqrt(pow(errors.sigma_pol_1st / output.sigma_pol_1st, 2.)
+				errors.asymm_1st = abs(output.asymm_1st) * sqrt(pow(errors.sigma_pol_1st / output.sigma_pol_1st, 2.)
 						+ pow(errors.sigma_unpol_1st / output.sigma_unpol_1st, 2.));
 				output.sigma_1st = output.sigma_pol_1st + output.sigma_unpol_1st;
 				errors.sigma_1st = sqrt(pow(errors.sigma_pol_1st,2.) + pow(errors.sigma_unpol_1st,2.));
@@ -2062,6 +1474,8 @@ int PES::initialization(){
 		}
 	}
 
+
+// Electron target
 	if (param.flag[param.target] == 2) {
 
 			if (param.flag[param.LO] == 1) {
@@ -2126,6 +1540,7 @@ int PES::initialization(){
 	return 0;
 
 }
+
 
 int PES::events(){
 
@@ -2439,6 +1854,7 @@ int PES::events(){
 
 }
 
+
 int PES::shiftQ2(const double thl_deg) {
 
 	double  average_deltaQ2, sigma_thl, inelastic_thl,
@@ -2547,6 +1963,7 @@ int PES::shiftQ2(const double thl_deg) {
 
 		return 0;
 }
+
 
 int PES::sigma_diff_Omega_l(const double thl_deg) {
 
@@ -2897,7 +2314,7 @@ int PES::sigma_diff_Omega_l(const double thl_deg) {
 			errors.sigma_pol_1st = errors.sigma_pol_inelastic_1st;
 			output.asymm_1st = output.sigma_pol_1st / output.sigma_unpol_1st;
 			output.rel_asymm_1st = - 100.*(output.asymm_1st - output.asymm_born) / output.asymm_born;
-			errors.asymm_1st = output.asymm_1st * sqrt(pow(errors.sigma_pol_1st / output.sigma_pol_1st, 2.)
+			errors.asymm_1st = abs(output.asymm_1st) * sqrt(pow(errors.sigma_pol_1st / output.sigma_pol_1st, 2.)
 					+ pow(errors.sigma_unpol_1st / output.sigma_unpol_1st, 2.));
 			output.sigma_1st = output.sigma_pol_1st + output.sigma_unpol_1st;
 			errors.sigma_1st = sqrt(pow(errors.sigma_pol_1st,2.) + pow(errors.sigma_unpol_1st,2.));
@@ -2989,7 +2406,7 @@ int PES::sigma_diff_Omega_l(const double thl_deg) {
 
 		output.asymm_2nd = output.sigma_pol_2nd / output.sigma_unpol_2nd;
 		output.rel_asymm_2nd = -100.*(output.asymm_2nd - output.asymm_born) / output.asymm_born;
-		errors.asymm_2nd = output.asymm_2nd * sqrt(pow(errors.sigma_pol_2nd / output.sigma_pol_2nd, 2.)
+		errors.asymm_2nd = abs(output.asymm_2nd) * sqrt(pow(errors.sigma_pol_2nd / output.sigma_pol_2nd, 2.)
 				+ pow(errors.sigma_unpol_2nd / output.sigma_unpol_2nd, 2.));
 		output.sigma_2nd = output.sigma_pol_2nd + output.sigma_unpol_2nd;
 		errors.sigma_2nd = sqrt(pow(errors.sigma_pol_2nd,2.) + pow(errors.sigma_unpol_2nd,2.));
@@ -3040,7 +2457,7 @@ int PES::sigma_diff_Omega_l(const double thl_deg) {
 					output.asymm_1st = output.sigma_pol_1st / output.sigma_unpol_1st;
 					output.asymm_1st *= param.P;
 					output.rel_asymm_1st = - 100.*(output.asymm_1st - output.asymm_born) / output.asymm_born;
-					errors.asymm_1st = output.asymm_1st * sqrt(pow(errors.sigma_pol_1st / output.sigma_pol_1st, 2.)
+					errors.asymm_1st = abs(output.asymm_1st) * sqrt(pow(errors.sigma_pol_1st / output.sigma_pol_1st, 2.)
 							+ pow(errors.sigma_unpol_1st / output.sigma_unpol_1st, 2.));
 					output.sigma_1st = output.sigma_pol_1st + output.sigma_unpol_1st;
 					errors.sigma_1st = sqrt(pow(errors.sigma_pol_1st,2.) + pow(errors.sigma_unpol_1st,2.));
@@ -3123,7 +2540,7 @@ int PES::sigma_diff_Omega_l(const double thl_deg) {
 				errors.sigma_pol_1st = errors.sigma_pol_inelastic_1st;
 				output.asymm_born = output.sigma_pol_born / output.sigma_unpol_born;
 				output.asymm_1st = output.sigma_pol_1st / output.sigma_unpol_1st;
-				errors.asymm_1st = output.asymm_1st * sqrt(pow(errors.sigma_pol_1st / output.sigma_pol_1st, 2.)
+				errors.asymm_1st = abs(output.asymm_1st) * sqrt(pow(errors.sigma_pol_1st / output.sigma_pol_1st, 2.)
 						+ pow(errors.sigma_unpol_1st / output.sigma_unpol_1st, 2.));
 				output.sigma_1st = output.sigma_pol_1st + output.sigma_unpol_1st;
 				errors.sigma_1st = sqrt(pow(errors.sigma_pol_1st,2.) + pow(errors.sigma_unpol_1st,2.));
@@ -3172,6 +2589,7 @@ int PES::sigma_diff_Omega_l(const double thl_deg) {
 
 	return 0;
 }
+
 
 double PES::delta(const double thl_deg) {
 
@@ -3229,6 +2647,7 @@ double PES::delta(const double thl_deg) {
 	return delta;
 }
 
+
 double PES::running_sw2(const double Q2) {
 
 	param.final_param(input);
@@ -3240,12 +2659,14 @@ double PES::running_sw2(const double Q2) {
 	return integrands.CS.VC.kappa_weak(Q2)*param.sw2;
 }
 
+
 double PES::get_total_unpol_cross_section(const double E) {
 
 	param.en = round(E/param.Delta_E) * param.Delta_E;
 
 	return output.sigma_unpol_1st_vect[int(param.en/param.Delta_E) - int(param.min[param.E]/param.Delta_E)];
 }
+
 
 void PES::set_final_state() {
 
@@ -3318,6 +2739,7 @@ void PES::set_final_state() {
 	FS.event_no++;
 }
 
+
 void PES::write_output() {
 
 	time_t present_time;
@@ -3329,25 +2751,26 @@ void PES::write_output() {
 		param.output_file += ".out";
 		out.precision(7);
 
+// Output to file
 		out.open(param.output_file.c_str());
 
 		out <<"##########################################################################\n"
-				<<"##                               POLARES "<< VERSION << "\n"
-				<<"##\n"
-				<<"##       Radiative Corrections for Polarized Electron-Proton Scattering     \n"
-				<<"##\n"
-				<<"##                              R.-D. Bucoveanu                             \n"
-				<<"##\n"
-				<<"##                         "<<dt
-		        <<"##\n"
-				<<"## If you use POLARES please cite R.-D. Bucoveanu and H. Spiesberger, \n"
-				<<"## Eur. Phys. J. A (2019) 55: 57, arXiv:1811.04970 [hep-ph]. \n"
-		        <<"## Copyright (c) Razvan Bucoveanu, 2019. E-mail: rabucove@uni-mainz.de\n";
-		out <<"##########################################################################\n"
-				<<"##                                  Input                                   \n"
-				<<"##\n"
-				<<"## [General Input]                                                          \n"
-				<<"## Type of incident lepton = ";
+            <<"##                               POLARES "<< VERSION << "\n"
+            <<"##\n"
+            <<"##       Radiative Corrections for Polarized Electron-Proton Scattering   \n"
+            <<"##\n"
+            <<"##                              R.-D. Bucoveanu                           \n"
+            <<"##\n"
+            <<"##                         "<<dt
+            <<"##\n"
+            <<"## If you use POLARES please cite R.-D. Bucoveanu and H. Spiesberger,     \n"
+            <<"## Eur. Phys. J. A (2019) 55: 57, arXiv:1811.04970 [hep-ph].              \n"
+            <<"## Copyright (c) Razvan Bucoveanu, 2019. E-mail: rabucove@uni-mainz.de    \n"
+            <<"##########################################################################\n";
+        out <<"##                                  Input                                 \n"
+            <<"##\n"
+            <<"## [General Input]                                                        \n"
+            <<"## Type of incident lepton = ";
 		if (param.flag[param.lepton] == 0) out<<"electron\n";
 		if (param.flag[param.lepton] == 1) out<<"positron\n";
 		if (param.flag[param.lepton] == 2) out<<"muon\n";
@@ -3375,15 +2798,15 @@ void PES::write_output() {
 		if (param.flag[param.form_factors] == 2) out <<"Friedrich Walcher\n";
 		if (param.flag[param.form_factors] == 3) out <<"Static Limit\n";
 		if (param.flag[param.form_factors] == 4) out <<"User defined\n";
+        out <<"## Degree of Polarization = "<<param.P*100.<<"%\n";
 		out <<"## Calculate the asymmetry = ";
 		if (param.flag[param.asymmetry] == 0) out<<"no\n";
 		if (param.flag[param.asymmetry] == 1) {
 			out<<"yes\n";
-			out<<"## Degree of Polarization = "<<param.P*100.<<"%\n";
 			out<<"## sin2thetaW = "<<param.sw2<<"\n";
-			out<<"## kappa form factor = ";
-			if (param.flag[param.kappa_weak] == 0) out<<"0 - no running for sin2thetaW\n";
-			if (param.flag[param.kappa_weak] == 1) out<<"1 - full contribution for the running of sin2thetaW\n";
+			out<<"## Running weak mixing angle = ";
+			if (param.flag[param.kappa_weak] == 0) out<<"0 - no running, fixed sin2thetaW\n";
+			if (param.flag[param.kappa_weak] == 1) out<<"1 - effective sin2thetaW from CM\n";
 		}
 		out <<"## Maximum number of evaluations for 1st order bremsstrahlung = "<<param.MAXEVAL_1st<<"\n";
 		if (param.flag[param.brems] == 2 || param.flag[param.brems] == 3)
@@ -3395,14 +2818,17 @@ void PES::write_output() {
 		out<<"##\n";
 		out <<"## [E_gamma < Delta]\n";
 		out <<"## Vacuum Polarization = ";
-		if (param.flag[param.vac_pol] == 0) out<<"no contribution\n";
+		if (param.flag[param.vac_pol] == 0) out<<"not included\n";
 		if (param.flag[param.vac_pol] == 1) out<<"Only electron-positron loops\n";
 		if (param.flag[param.vac_pol] == 2) out<<"Full leptonic contributions\n";
-		if (param.flag[param.vac_pol] == 3) out<<"Hadronic contributions (Ignatov)\n";
-		if (param.flag[param.vac_pol] == 4) out<<"Hadronic contributions (Jegerlehner)\n";
-		if (param.flag[param.vac_pol] == 5) out<<"Hadronic contributions (NKT18))\n";
+		if (param.flag[param.vac_pol] == 3) 
+            out<<"Including hadronic contributions (Ignatov)\n";
+		if (param.flag[param.vac_pol] == 4) 
+            out<<"Including adronic contributions (Jegerlehner)\n";
+		if (param.flag[param.vac_pol] == 5) 
+            out<<"Including hadronic contributions (NKT18))\n";
 		out <<"## Two-photon exchange correction (TPE) = ";
-		if (param.flag[param.tpe] == 0) out<<"no contribution\n";
+		if (param.flag[param.tpe] == 0) out<<"not included\n";
 		if (param.flag[param.tpe] == 1) out<<"Calculation for a point like particle (Feshbach term)\n";
 		if (param.flag[param.tpe] == 2) out<<"Tomalak total calculation\n";
 		out<<"##\n";
@@ -3410,11 +2836,23 @@ void PES::write_output() {
 		out <<"## Type of hard-photon bremsstrahlung = ";
 		if (param.flag[param.brems] == 0) out<<"no hard photon contribution\n";
 		if (param.flag[param.brems] == 1) out<<"1st order\n";
-		if (param.flag[param.brems] == 2) out<<"1st order and 2nd order\n";
+		if (param.flag[param.brems] == 2) out<<"1st and 2nd order\n";
 		if (param.flag[param.brems] == 3) out<<"2nd order\n";
-		out <<"## Hadronic Radiation = ";
-		if (param.flag[param.brems_hadr] == 0) out<<"no hadronic radiation contribution\n";
-		if (param.flag[param.brems_hadr] == 1) out<<"1st order\n";
+        out <<"## Hadronic sof+virtual corrections = ";
+        if (param.flag[param.hadr_corr] == 0) out<<"no hadronic corrections\n";
+        if (param.flag[param.hadr_corr] == 1) out<<"only tpe and lep-had interference\n";
+        if (param.flag[param.hadr_corr] == 2) out<<"only hadronic corrections\n";
+        if (param.flag[param.hadr_corr] == 3) out<<"complete tpe + interference + hadronic\n";
+		out <<"## Hadronic radiation = ";
+		if (param.flag[param.brems_hadr] == 0) out<<"no contribution from hadronic radiation \n";
+		if (param.flag[param.brems_hadr] == 1) out<<"only lep-had interference\n";
+        if (param.flag[param.brems_hadr] == 2) out<<"only hadronic radiation\n";
+        if (param.flag[param.brems_hadr] == 3) out<<"complete interference + hadronic\n";
+        if (param.flag[param.brems_hadr] != param.flag[param.hadr_corr]) {
+            out<<"***** WARNING: ***** \n"
+               <<"***** Input for Hadronic corrections and Hadronic Radiation \n" 
+               <<"***** do not match. Result unphysical and for testing only! \n";
+        }
 		out <<"## E_gamma max = "<<param.max[param.E_gamma] <<" GeV\n";
 		out <<"## E' min = "<<param.min[param.E_prime] <<" GeV\n";
 		out <<"## E' max = "<<param.max[param.E_prime] <<" GeV\n";
@@ -3422,61 +2860,102 @@ void PES::write_output() {
 		out <<"## theta_gamma max = "<<param.max[param.theta_gamma_deg]<<" degrees\n";
 		//	out <<"## Q'^2 min = "<<param.min[param.Q2_prime]<<" GeV^2\n";
 		//	out <<"## Q'^2 max = "<<param.max[param.Q2_prime]<<" GeV^2\n";
-		out <<"##########################################################################\n"
-				<<"##                   Numerical integration results                          \n"
-				<<"##\n";
-		if (output.sigma_unpol_born != 0)
-			out <<"## Sigma unpol Born = " << output.sigma_unpol_born
-			<<" +- "<< errors.sigma_unpol_born << " nb\n";
-		if (output.sigma_unpol_elastic_1st != 0)
-			out <<"## Sigma unpol soft-photon 1st order = " << output.sigma_unpol_elastic_1st
-			<<" +- "<< errors.sigma_unpol_elastic_1st << " nb\n";
-		if (output.sigma_unpol_elastic_2nd != 0)
-			out <<"## Sigma unpol soft-photon 2nd order = " << output.sigma_unpol_elastic_2nd
-			<<" +- "<< errors.sigma_unpol_elastic_2nd << " nb\n";
-		if (output.sigma_unpol_inelastic_1st != 0)
-			out <<"## Sigma unpol hard-photon 1st order = " << output.sigma_unpol_inelastic_1st
-			<<" +- "<< errors.sigma_unpol_inelastic_1st << " nb\n";
-		if (output.sigma_unpol_inelastic_loop != 0)
-			out <<"## Sigma unpol hard-photon + 1loop = " << output.sigma_unpol_inelastic_loop
-			<<" +- "<< errors.sigma_unpol_inelastic_loop << " nb\n";
-		if (output.sigma_unpol_inelastic_2nd != 0)
-			out <<"## Sigma unpol hard_photon 2nd order = " << output.sigma_unpol_inelastic_2nd
-			<<" +- "<< errors.sigma_unpol_inelastic_2nd << " nb\n";
-		if (output.sigma_unpol_1st != 0)
-			out <<"## Sigma unpol 1st order = " << output.sigma_unpol_1st
-			<<" +- "<< errors.sigma_unpol_1st << " nb\n";
-		if (output.sigma_unpol_2nd != 0)
-			out <<"## Sigma unpol 2nd order = " << output.sigma_unpol_2nd
-			<<" +- "<< errors.sigma_unpol_2nd << " nb\n";
-		if (output.sigma_pol_elastic_1st != 0)
-			out <<"## Sigma pol soft-photon 1st order = " << output.sigma_pol_elastic_1st
-			<<" +- "<< errors.sigma_pol_elastic_1st << " nb\n";
-		if (output.sigma_pol_elastic_2nd != 0)
-			out <<"## Sigma pol soft-photon 2nd order = " << output.sigma_pol_elastic_2nd
-			<<" +- "<< errors.sigma_pol_elastic_2nd << " nb\n";
-		if (output.sigma_pol_inelastic_1st != 0)
-			out <<"## Sigma pol hard-photon 1st order = " << output.sigma_pol_inelastic_1st
-			<<" +- "<< errors.sigma_pol_inelastic_1st << " nb\n";
-		if (output.sigma_pol_inelastic_loop != 0)
-			out <<"## Sigma pol hard photon + 1 loop = " << output.sigma_pol_inelastic_loop
-			<<" +- "<< errors.sigma_pol_inelastic_loop << " nb\n";
-		if (output.sigma_pol_inelastic_2nd != 0)
-			out <<"## Sigma pol hard-photon 2nd order = " << output.sigma_pol_inelastic_2nd
-			<<" +- "<< errors.sigma_pol_inelastic_2nd << " nb\n";
-		if (output.sigma_pol_1st != 0) out << "## Sigma pol 1st order = " << output.sigma_pol_1st
-				<< " +- " << errors.sigma_pol_1st << " nb\n";
-		if (output.sigma_pol_2nd != 0) out << "## Sigma pol 2nd order = " << output.sigma_pol_2nd
-				<< " +- " << errors.sigma_pol_2nd << " nb\n";
-		if (output.sigma_pol_born != 0)
-			out <<"## Sigma pol Born = " << output.sigma_pol_born
-			<<" +- "<< errors.sigma_pol_born << " nb\n";
-		if (output.asymm_1st != 0)
-			out <<"## Asymm 1st order = " << output.asymm_1st <<" +- "<< errors.asymm_1st << "\n";
-		if (output.asymm_2nd != 0)
-			out <<"## Asymm 2nd order = " << output.asymm_2nd <<" +- "<< errors.asymm_2nd << "\n";
-		if (output.asymm_born != 0)
-			out <<"## Asymm Born = " << output.asymm_born <<" +- "<< errors.asymm_born << "\n";
+		out <<"\n"
+            <<"##########################################################################\n"
+            <<"                     Results of the numerical integration                 \n"
+            <<"\n";
+
+        out << "Leading-order results:\n";
+        out << "Sigma unpol Born =                        " 
+            << output.sigma_unpol_born
+            << " +- "<< errors.sigma_unpol_born << " nb\n";
+        out << "Sigma pol Born =                          " 
+            << output.sigma_pol_born
+            << " +- "<< errors.sigma_pol_born << " nb\n";
+        out << "\n";
+        out << "\n";
+        
+        out << "First-order corrections:\n";
+        out << "Sigma unpol Born + soft-photon + 1-loop = " 
+            << output.sigma_unpol_elastic_1st
+            << " +- "<< errors.sigma_unpol_elastic_1st << " nb\n";
+        out << "Sigma unpol 1 hard photon hadr interf=    "
+            << output.sigma_unpol_inelastic_1st_hadr_interf
+            << " +- " << errors.sigma_unpol_inelastic_1st_hadr_interf << " nb\n";
+        out << "Sigma unpol 1 hard photon hadronic =      "
+            << output.sigma_unpol_inelastic_1st_hadr
+            << " +- " << errors.sigma_unpol_inelastic_1st_hadr << " nb\n";
+        out << "Sigma unpol 1 hard photon (incl.hadr) =   " 
+            << output.sigma_unpol_inelastic_1st
+            << " +- "<< errors.sigma_unpol_inelastic_1st << " nb\n";
+        out << "Sigma unpol 1st order (complete) =        " 
+            << output.sigma_unpol_1st
+            << " +- "<< errors.sigma_unpol_1st << " nb\n";
+        out << "\n";
+        out << "Sigma pol Born + soft-photon + 1-loop =   " 
+            << output.sigma_pol_elastic_1st
+            << " +- "<< errors.sigma_pol_elastic_1st << " nb\n";
+        out << "Sigma pol 1 hard photon (leptonic only) = " 
+            << output.sigma_pol_inelastic_1st
+            << " +- "<< errors.sigma_pol_inelastic_1st << " nb\n";
+        out << "Sigma pol 1st order (complete) =          " 
+            << output.sigma_pol_1st
+            << " +- " << errors.sigma_pol_1st << " nb\n";
+        out << "\n";
+        out << "\n";
+
+        out << "Second-order corrections:\n";
+        out << "Sigma unpol Born + 1st + 2 soft photons + 2-loop = " 
+            << output.sigma_unpol_elastic_2nd
+            << " +- "<< errors.sigma_unpol_elastic_2nd << " nb\n";
+        out << "Sigma unpol 1 hard photon with loop =              " 
+            << output.sigma_unpol_inelastic_loop
+            << " +- "<< errors.sigma_unpol_inelastic_loop << " nb\n";
+        out << "Sigma unpol 2 hard photons =                       " 
+            << output.sigma_unpol_inelastic_2nd
+            << " +- "<< errors.sigma_unpol_inelastic_2nd << " nb\n";
+        out << "Sigma unpol hard photon + soft photon (fin) =      " 
+            << output.sigma_unpol_2nd_add
+            << " +- " << errors.sigma_unpol_2nd_add << " nb\n";
+        out << "Sigma unpol 2nd order (complete) =                 " 
+            << output.sigma_unpol_2nd
+            << " +- "<< errors.sigma_unpol_2nd << " nb\n";
+        out << "\n"; 
+
+        out << "Sigma pol Born + 1st + 2 soft photons + 2-loop =   " 
+            << output.sigma_pol_elastic_2nd
+            << " +- "<< errors.sigma_pol_elastic_2nd << " nb\n";
+        out << "Sigma pol 1 hard photon + with loop =              " 
+            << output.sigma_pol_inelastic_loop
+            << " +- "<< errors.sigma_pol_inelastic_loop << " nb\n";
+        out << "Sigma pol 2 hard photons =                         " 
+            << output.sigma_pol_inelastic_2nd
+            << " +- "<< errors.sigma_pol_inelastic_2nd << " nb\n";
+        out << "Sigma pol hard photon + soft photon (fin) =        " 
+            << output.sigma_pol_2nd_add
+            << " +- " << errors.sigma_pol_2nd_add << " nb\n";
+        out << "Sigma pol 2nd order (complete) =                   " 
+            << output.sigma_pol_2nd
+            << " +- " << errors.sigma_pol_2nd << " nb\n";
+        out << "\n"; 
+        out << "\n"; 
+
+        out << "Polarization asymmetry:\n";
+        out << "PV asymmetry at leading order =                " 
+            << output.asymm_born 
+            << " +- "<< errors.asymm_born << "\n";
+        out << "PV asymmetry including 1st order corrections = " 
+            << output.asymm_1st 
+            << " +- "<< errors.asymm_1st << "\n";
+        out << "PV asymmetry including 2nd order corrections = " 
+            << output.asymm_2nd 
+            << " +- "<< errors.asymm_2nd << "\n";
+        out << "1st order correction in percent = " 
+            << output.rel_asymm_1st << "\n";
+        out << "2nd order correction in percent = " 
+            << output.rel_asymm_2nd << "\n";
+        out << "\n"; 
+        out << "\n"; 
 
 		out <<"##########################################################################";
 
@@ -3485,18 +2964,20 @@ void PES::write_output() {
 		param.output_file.erase (param.output_file.end()-4, param.output_file.end());
 	}
 
-	std::cout <<"\n##########################################################################\n"
-			<<"##                               POLARES "<< VERSION << "\n"
-			<<"##\n"
-			<<"##       Radiative Corrections for Polarized Electron-Proton Scattering     \n"
-			<<"##\n"
-			<<"##                              R.-D. Bucoveanu                             \n"
-			<<"##\n"
-			<<"##                         "<<dt
-	        <<"##\n"
-			<<"## If you want to use POLARES please cite R.-D. Bucoveanu and H. Spiesberger, \n"
-			<<"## Eur. Phys. J. A (2019) 55: 57, arXiv:1811.04970 [hep-ph]. \n"
-	        <<"## Copyright (c) Razvan Bucoveanu, 2019. E-mail: rabucove@uni-mainz.de\n";
+// Echo output at terminal
+	std::cout <<"\n"
+              <<"##########################################################################\n"
+			  <<"##                               POLARES "<< VERSION << "\n"
+			  <<"##\n"
+			  <<"##       Radiative Corrections for Polarized Electron-Proton Scattering   \n"
+			  <<"##\n"
+			  <<"##                              R.-D. Bucoveanu                           \n"
+			  <<"##\n"
+			  <<"##                         "<<dt
+	          <<"##\n"
+			  <<"## If you use POLARES please cite R.-D. Bucoveanu and H. Spiesberger,     \n"
+			  <<"## Eur. Phys. J. A (2019) 55: 57, arXiv:1811.04970 [hep-ph].              \n"
+	          <<"## Copyright (c) Razvan Bucoveanu, 2019. E-mail: rabucove@uni-mainz.de    \n";
 
 	if (param.flag[param.echo_input] == 1) {
 
@@ -3534,13 +3015,12 @@ void PES::write_output() {
 		if (param.flag[param.asymmetry] == 0) std::cout<<"no\n";
 		if (param.flag[param.asymmetry] == 1) {
 			std::cout<<"yes\n";
-			std::cout<<"## Degree of Polarization = "<<param.P*100.<<"%\n";
 			std::cout<<"## sin2thetaW = "<<param.sw2<<"\n";
-			std::cout<<"## kappa form factor = ";
-			if (param.flag[param.kappa_weak] == 0) std::cout<<"0 - no running for sin2thetaW\n";
-			if (param.flag[param.kappa_weak] == 1) std::cout<<"1 - full contribution for the running of sin2thetaW\n";
+			std::cout<<"## Running weak mixing angle = ";
+			if (param.flag[param.kappa_weak] == 0) std::cout<<"0 - no running, fixed sin2thetaW\n";
+			if (param.flag[param.kappa_weak] == 1) std::cout<<"1 - effective sin2thetaW from CM\n";
 		}
-		std::cout <<"## Maximum number of evaluations for 1st order bremsstrahlung = "<<param.MAXEVAL_1st<<"\n";
+        std::cout <<"## Maximum number of evaluations for 1st order bremsstrahlung = "<<param.MAXEVAL_1st<<"\n";
 		if (param.flag[param.brems] == 2 || param.flag[param.brems] == 3)
 			std::cout <<"## Maximum number of evaluations for 2nd order bremsstrahlung = "<<param.MAXEVAL_2nd<<"\n";
 //		std::cout <<"## Minimum number of evaluations = "<<param.MINEVAL<<"\n";
@@ -3550,22 +3030,41 @@ void PES::write_output() {
 		std::cout<<"##\n";
 		std::cout <<"## [E_gamma < Delta]\n";
 		std::cout <<"## Vacuum Polarization = ";
-		if (param.flag[param.vac_pol] == 0) std::cout<<"no contribution\n";
+		if (param.flag[param.vac_pol] == 0) std::cout<<"not included\n";
 		if (param.flag[param.vac_pol] == 1) std::cout<<"Only electron-positron loops\n";
 		if (param.flag[param.vac_pol] == 2) std::cout<<"Full leptonic contributions\n";
-		if (param.flag[param.vac_pol] == 3) std::cout<<"Hadronic contributions\n";
+		if (param.flag[param.vac_pol] == 3) 
+            std::cout<<"Including hadronic contributions (Ignatov)\n";
+        if (param.flag[param.vac_pol] == 4) 
+            std::cout<<"Including hadronic contributions (Jegerlehner)\n";
+        if (param.flag[param.vac_pol] == 5) {
+            std::cout<<"Including hadronic contributions (KNT18)\n"; 
+            std::cout<<"***** Grid file needed ! \n";
+        }
 		std::cout <<"## Two-photon exchange correction (TPE) = ";
-		if (param.flag[param.tpe] == 0) std::cout<<"no contribution\n";
+		if (param.flag[param.tpe] == 0) std::cout<<"not included\n";
 		if (param.flag[param.tpe] == 1) std::cout<<"Calculation for a point like particle (Feshbach term)\n";
 		std::cout<<"##\n";
 		std::cout <<"## [E_gamma > Delta]\n";
-		std::cout <<"## Type of Bremsstrahlung = ";
+		std::cout <<"## Type of hard-photon bremsstrahlung = ";
 		if (param.flag[param.brems] == 1) std::cout<<"1st order\n";
-		if (param.flag[param.brems] == 2) std::cout<<"1st order and 2nd order\n";
+		if (param.flag[param.brems] == 2) std::cout<<"1st and 2nd order\n";
 		if (param.flag[param.brems] == 3) std::cout<<"2nd order\n";
-		std::cout <<"## Hadronic Radiation = ";
-		if (param.flag[param.brems_hadr] == 0) std::cout<<"no hadronic radiation contribution\n";
-		if (param.flag[param.brems_hadr] == 1) std::cout<<"1st order\n";
+        std::cout <<"## Hadronic soft+virtual corrections = ";
+        if (param.flag[param.hadr_corr] == 0) std::cout<<"no hadronic corrections\n";
+        if (param.flag[param.hadr_corr] == 1) std::cout<<"only tpe and lep-had interference\n";
+        if (param.flag[param.hadr_corr] == 2) std::cout<<"only hadronic corrections\n";
+        if (param.flag[param.hadr_corr] == 3) std::cout<<"complete tpe + interference + hadronic\n";
+		std::cout <<"## Hadronic radiation = ";
+        if (param.flag[param.brems_hadr] == 0) std::cout<<"no contribution from hadronic radiation \n";
+        if (param.flag[param.brems_hadr] == 1) std::cout<<"only lep-had interference\n";
+        if (param.flag[param.brems_hadr] == 2) std::cout<<"only hadronic radiation\n";
+        if (param.flag[param.brems_hadr] == 3) std::cout<<"complete interference + hadronic\n";
+        if (param.flag[param.brems_hadr] != param.flag[param.hadr_corr]) {
+            std::cout<<"***** WARNING: ***** \n"
+                     <<"***** Input for Hadronic corrections and Hadronic Radiation \n" 
+                     <<"***** do not match. Result unphysical and for testing only! \n";
+        }
 		std::cout <<"## E_gamma max = "<<param.max[param.E_gamma] <<" GeV\n";
 		std::cout <<"## E' min = "<<param.min[param.E_prime] <<" GeV\n";
 		std::cout <<"## E' max = "<<param.max[param.E_prime] <<" GeV\n";
@@ -3574,17 +3073,19 @@ void PES::write_output() {
 	}
 }
 
+
 bool PES::change_energy_initialization(const double E){
 	bool E_is_OK(true);
 
 	if (E > 10.) {
 		E_is_OK = false;
-		std::cout << "Warning! Energy has to be smaller than 10 GeV for generating events";
+		std::cout << "Warning! Energy has to be smaller than 10 GeV for generating events\n\n";
 	}
 
 	param.en = E;
 	return E_is_OK;
 }
+
 
 bool PES::change_energy_events(const double E){
 	bool E_is_OK(true);
@@ -3601,6 +3102,7 @@ bool PES::change_energy_events(const double E){
 	return E_is_OK;
 }
 
+
 bool PES::set_child_process(const int child_process) {
 	bool seed_is_OK(false);
 
@@ -3614,6 +3116,7 @@ bool PES::set_child_process(const int child_process) {
 
 	return seed_is_OK;
 }
+
 
 double PES::get_E() {
 

--- a/src/parameters.cpp
+++ b/src/parameters.cpp
@@ -3,11 +3,14 @@
  *
  *  Created on: Dec 3, 2015
  *      Author: razvan
+ *
+ *  Modified: Jan 24, 2022 by HS
  */
 
 #include <cmath>
 #include "const.h"
-#include "ReadConfigFile.h"    //Code that reads from the input file v2.1 (Copyright (c) 2004 Richard J. Wagner)
+#include "ReadConfigFile.h"    
+//Code that reads from the input file v2.1 (Copyright (c) 2004 Richard J. Wagner)
 #include <iostream>
 #include <stdlib.h>
 #include "parameters.h"
@@ -16,357 +19,318 @@
 using namespace constants;
 using namespace POLARES;
 
-Parameters::Parameters()
-: SEED(1), MINEVAL(0), MAXEVAL_LO(1e7), MAXEVAL_1st(1e7), maxeval_1st_aux(0),
-MAXEVAL_gamma_loop(1e7), MAXEVAL_2nd(1e8), MAXEVAL_2nd_add(1e8),
-EPSREL(1e-100), no_cores(4), GRIDNO_elastic(0), GRIDNO_brems(1),
-GRIDNO_brems_hadr(13), GRIDNO_brems_hadr_interf(14),
-GRIDNO_brems_1st(2), GRIDNO_brems_test(3), GRIDNO_brems_interf(6),
-GRIDNO_brems_2nd(7), GRIDNO_brems_2nd_l1k1(8), GRIDNO_brems_2nd_l1k2(9),
-GRIDNO_brems_2nd_l2k1(10), GRIDNO_brems_2nd_l2k2(11),
-GRIDNO_brems_interf_2nd(12), GRIDNO_brems_interf_2nd_1(13),
-GRIDNO_brems_interf_2nd_2(14), GRIDNO_brems_2nd_add_l1k1(15),
-GRIDNO_brems_2nd_add_l1k2(16), GRIDNO_brems_2nd_add_l2k1(17),
-GRIDNO_brems_2nd_add_l2k2(18), NSTART(1000),
-NINCREASE(500), NBATCH(1000), NNEW(100000), NMIN(200), FLATNESS(5), P(1),
-m(me), m2(me2), M(mpr), M2(mpr2), sw2(sw2_msbar), Z_lepton(-1.), Z_target(1.),
-en(0.155), l1(0), thl(0), Q2(0), eps(0), thg(0), aux(0), Delta_E(0),
-Delta_eps(0), mu_dim(0), lambda(m2), check_input(0) {
-}
+Parameters::Parameters(): 
+    SEED(1), MINEVAL(0), MAXEVAL_LO(1e7), MAXEVAL_1st(1e7), maxeval_1st_aux(0),
+    MAXEVAL_gamma_loop(1e7), MAXEVAL_2nd(1e8), MAXEVAL_2nd_add(1e8),
+    EPSREL(1e-100), no_cores(4), GRIDNO_elastic(0), GRIDNO_brems(1),
+    GRIDNO_brems_hadr(13), GRIDNO_brems_hadr_interf(14),
+    GRIDNO_brems_1st(2), GRIDNO_brems_test(3), GRIDNO_brems_interf(6),
+    GRIDNO_brems_2nd(7), GRIDNO_brems_2nd_l1k1(8), GRIDNO_brems_2nd_l1k2(9),
+    GRIDNO_brems_2nd_l2k1(10), GRIDNO_brems_2nd_l2k2(11),
+    GRIDNO_brems_interf_2nd(12), GRIDNO_brems_interf_2nd_1(13),
+    GRIDNO_brems_interf_2nd_2(14), GRIDNO_brems_2nd_add_l1k1(15),
+    GRIDNO_brems_2nd_add_l1k2(16), GRIDNO_brems_2nd_add_l2k1(17),
+    GRIDNO_brems_2nd_add_l2k2(18), NSTART(1000),
+    NINCREASE(500), NBATCH(1000), NNEW(100000), NMIN(200), FLATNESS(5), 
+    P(1), m(me), m2(me2), M(mpr), M2(mpr2), sw2(sw2_msbar), 
+    Z_lepton(-1.), Z_target(1.),
+    en(0.155), l1(0), thl(0), Q2(0), eps(0), thg(0), aux(0), Delta_E(0),
+    Delta_eps(0), mu_dim(0), lambda(m2), check_input(0) 
+    {}
+
 
 int Parameters::read_input(const Input& input) {
-//		    function for reading the input file
 
-		check_input = 1;
-
-		if (input.input_file.empty()) {
-
-//			basic input
-			en = input.E;
-			min[theta_l] = input.thl_min * pi/180.;
-			min[theta_l_deg] = input.thl_min;
-			max[theta_l] = input.thl_max * pi/180.;
-			max[theta_l_deg] = input.thl_max;
-			min[Q2_elastic] = input.Q2min;
-			max[Q2_elastic] = input.Q2max;
-			min[E_gamma] = input.Delta;
-			min[E_gamma_prime] = min[E_gamma];
-			max[E_gamma] = input.E_gamma_max;
-			max[E_gamma_prime] = max[E_gamma];
-			min[theta_gamma] = input.thg_min * pi/180.;
-			max[theta_gamma] = input.thg_max * pi/180.;
-			min[E_prime] = input.E_prime_min;
-			max[E_prime] = input.E_prime_max;
-			P = input.polarization;
-			sw2 = input.sw2;
-//			if (input.events != 0) flag[ps] = input.events;
-
-//			input for cuba library
-			FLATNESS = input.flatness;
-			SEED = input.seed;
-			EPSREL = input.epsrel;
-			no_cores = input.no_cores;
-			MAXEVAL_LO = input.no_eval_LO;
-			MAXEVAL_1st = input.no_eval_1st;
-			MAXEVAL_2nd = input.no_eval_2nd;
-			MAXEVAL_gamma_loop = input.no_eval_gamma_loop;
-			MAXEVAL_2nd_add = input.no_eval_2nd_add;
-			MINEVAL = input.no_min_eval;
-			NSTART = input.nstart;
-			NBATCH = input.nbatch;
-			NINCREASE = input.nincrease;
-			NNEW = input.nnew;
-			NMIN = input.nmin;
-
-//			input for flags
-			flag[form_factors] = input.flag[input.form_factors];
-			flag[echo_input] = input.flag[input.echo_input];
-			flag[brems] = input.flag[input.brems];
-			flag[brems_add] = input.flag[input.brems_add];
-			flag[brems_hadr] = input.flag[input.brems_hadr];
-			flag[PS] = input.flag[input.PS];
-			flag[asymmetry] = input.flag[input.asymmetry];
-			flag[LO] = input.flag[input.LO];
-			flag[order] = input.flag[input.order];
-			flag[hadr_corr] = input.flag[input.hadr_corr];
-			flag[kappa_weak] = input.flag[input.kappa_weak];
-			flag[vac_pol] = input.flag[input.vac_pol];
-			flag[tpe] = input.flag[input.tpe];
-			flag[lepton] = input.flag[input.lepton];
-			flag[target] = input.flag[input.target];
-			flag[int_method] = input.flag[input.int_method];
-			flag[GL] = input.flag[input.GL];
-			flag[int_output] = input.flag[input.int_output];
-			flag[cuts_born] = input.flag[input.cuts_born];
-
-//			Input for testing gamma_loop
-			Delta_eps = input.Delta_eps;
-			mu_dim = input.mu_dim;
-			lambda = input.lambda;
-
-//			Input for event generator
-			min[E] = input.E_min;
-			max[E] = input.E_max;
-			Delta_E = input.Delta_E;
-
-//			input for differential cross sections
-			thl = input.thl_deg * pi/180.;
-			thg = input.thg_deg * pi/180.;
-
-		}
-		else {
-		 ConfigFile CFile(input.input_file + ".in");
-
-		 CFile.readInto<double>(en,"Incident Lepton Energy", input.E);
-
-		 CFile.readInto<double>(min[theta_l_deg],"theta_l min", input.thl_min);
-		 min[theta_l] = (min[theta_l_deg]*pi)/180.;
-
-		 CFile.readInto<double>(max[theta_l_deg],"theta_l max", input.thl_max);
-		 max[theta_l] = (max[theta_l_deg]*pi)/180.;
-
-		 CFile.readInto<double>(min[Q2_elastic],"Q^2 min", input.Q2min);
-
-		 CFile.readInto<double>(max[Q2_elastic],"Q^2 max", input.Q2max);
-
-		 CFile.readInto<double>(min[E_gamma],"Delta", input.Delta);
-
-		 CFile.readInto<double>(min[E_gamma_prime],"Delta", input.Delta);
-
-		 CFile.readInto<double>(max[E_gamma],"E_gamma max", input.E_gamma_max);
-
-		 CFile.readInto<double>(max[E_gamma_prime],"E_gamma max", input.E_gamma_max);
-
-		 CFile.readInto<double>(min[E_p],"E_p min", input.E_p_min);
-
-		 CFile.readInto<double>(min[E],"E min", input.E_min);
-
-		 CFile.readInto<double>(max[E],"E max", input.E_max);
-
-		 CFile.readInto<double>(Delta_E,"Delta E", input.Delta_E);
-
-		 CFile.readInto<double>(min[theta_gamma_deg],"theta_gamma min", input.thg_min);
-		 min[theta_gamma] = min[theta_gamma_deg]*pi/180.;
-
-		 CFile.readInto<double>(max[theta_gamma_deg],"theta_gamma max", input.thg_max);
-		 max[theta_gamma] = max[theta_gamma_deg]*pi/180.;
-
-		 CFile.readInto<double>(min[E_prime],"E' min", input.E_prime_min);
-
-		 CFile.readInto<double>(max[E_prime],"E' max", input.E_prime_max);
-
-		 CFile.readInto<double>(P,"Polarization",input.polarization);
-
-		 CFile.readInto<double>(sw2,"sin2thetaW",input.sw2);
-
-		 CFile.readInto<double>(FLATNESS,"FLATNESS", input.flatness);
-
-		 CFile.readInto<double>(SEED,"Seed", input.seed);
-
-		 CFile.readInto<double>(EPSREL,"Relative Accuracy", input.epsrel);
-
-		 CFile.readInto<double>(Delta_eps,"Delta_eps", input.Delta_eps);
-
-		 CFile.readInto<double>(mu_dim,"mu_dim", input.mu_dim);
-
-		 CFile.readInto<double>(lambda,"lambda", input.lambda);
-
-		 CFile.readInto<int>(no_cores,"Number of cores", input.no_cores);
-
-		 CFile.readInto<long long int>(MAXEVAL_LO,"Maximum Number of Evaluations LO", input.no_eval_LO);
-
-		 CFile.readInto<long long int>(MAXEVAL_1st,"Maximum Number of Evaluations 1st", input.no_eval_1st);
-
-		 CFile.readInto<long long int>(MAXEVAL_gamma_loop,"Maximum Number of Evaluations gamma_loop", input.no_eval_gamma_loop);
-
-		 CFile.readInto<long long int>(MAXEVAL_2nd,"Maximum Number of Evaluations 2nd", input.no_eval_2nd);
-
-		 CFile.readInto<long long int>(MAXEVAL_2nd_add,"Maximum Number of Evaluations 2nd sg finite", input.no_eval_2nd_add);
-
-		 CFile.readInto<long long int>(MINEVAL,"Minimum Number of Evaluations", input.no_min_eval);
-
-		 CFile.readInto<long long int>(NSTART,"NSTART", input.nstart);
-
-		 CFile.readInto<long long int>(NINCREASE,"NINCREASE", input.nincrease);
-
-		 CFile.readInto<long long int>(NBATCH,"NBATCH", input.nbatch);
-
-		 CFile.readInto<long long int>(NNEW,"NNEW", input.nnew);
-
-		 CFile.readInto<long long int>(NMIN,"NMIN", input.nmin);
-
-		 CFile.readInto<int>(flag[form_factors], "Form Factors", input.flag[input.form_factors]);
-
-		 CFile.readInto<int>(flag[echo_input], "Echo Input", input.flag[input.echo_input]);
-
-//		 CFile.readInto<string>(output_file, "Output", "POLARES");
-
-		 CFile.readInto<int>(flag[brems], "Bremsstrahlung Type", input.flag[input.brems]);
-
-		 CFile.readInto<int>(flag[Delta_cut], "Type of Delta Cut", input.flag[input.Delta_cut]);
-
-		 CFile.readInto<int>(flag[brems_add], "Bremsstrahlung Add", input.flag[input.brems_add]);
-
-		 CFile.readInto<int>(flag[brems_hadr], "Hadronic Radiation", input.flag[input.brems_hadr]);
-
-		 CFile.readInto<int>(flag[hadr_corr], "Hadronic corrections", input.flag[input.hadr_corr]);
-
-		 CFile.readInto<int>(flag[PS], "Phase Space Parametrization", input.flag[input.PS]);
-
-		 CFile.readInto<int>(flag[asymmetry], "Asymmetry", input.flag[input.asymmetry]);
-
-		 CFile.readInto<int>(flag[LO], "Leading Order", input.flag[input.LO]);
-
-		 CFile.readInto<int>(flag[order], "Order SP_loop", input.flag[input.order]);
-
-		 CFile.readInto<int>(flag[kappa_weak], "Kappa Form Factor", input.flag[input.kappa_weak]);
-
-		 CFile.readInto<int>(flag[vac_pol], "Vacuum Polarization", input.flag[input.vac_pol]);
-
-		 CFile.readInto<int>(flag[tpe], "Two-photon exchange", input.flag[input.tpe]);
-
-		 CFile.readInto<int>(flag[lepton], "Incident Lepton", input.flag[input.lepton]);
-
-		 CFile.readInto<int>(flag[target], "Target Particle", input.flag[input.target]);
-
-		 CFile.readInto<int>(flag[int_method], "Integration method", input.flag[input.int_method]);
-
-		 CFile.readInto<int>(flag[GL], "Gamma Loop", input.flag[input.GL]);
-
-		 CFile.readInto<int>(flag[int_output],"Integration Output level", input.flag[input.int_output]);
-
-		 CFile.readInto<int>(flag[cuts_born], "Type of Cuts", input.flag[input.cuts_born]);
-		}
-
-		 return 0;
+    check_input = 1;
+
+    if (input.input_file.empty()) {
+// Set basic kinematic parameters from default
+        en = input.E;
+        min[theta_l] = input.thl_min * pi/180.;
+        min[theta_l_deg] = input.thl_min;
+        max[theta_l] = input.thl_max * pi/180.;
+        max[theta_l_deg] = input.thl_max;
+        min[Q2_elastic] = input.Q2min;
+        max[Q2_elastic] = input.Q2max;
+        min[E_gamma] = input.Delta;
+        min[E_gamma_prime] = min[E_gamma];
+        max[E_gamma] = input.E_gamma_max;
+        max[E_gamma_prime] = max[E_gamma];
+        min[theta_gamma] = input.thg_min * pi/180.;
+        max[theta_gamma] = input.thg_max * pi/180.;
+        min[E_prime] = input.E_prime_min;
+        max[E_prime] = input.E_prime_max;
+        P = input.polarization;
+        sw2 = input.sw2;
+// Parameters for the Cuba library
+        FLATNESS = input.flatness;
+        SEED = input.seed;
+        EPSREL = input.epsrel;
+        no_cores = input.no_cores;
+        MAXEVAL_LO = input.no_eval_LO;
+        MAXEVAL_1st = input.no_eval_1st;
+        MAXEVAL_2nd = input.no_eval_2nd;
+        MAXEVAL_gamma_loop = input.no_eval_gamma_loop;
+        MAXEVAL_2nd_add = input.no_eval_2nd_add;
+        MINEVAL = input.no_min_eval;
+        NSTART = input.nstart;
+        NBATCH = input.nbatch;
+        NINCREASE = input.nincrease;
+        NNEW = input.nnew;
+        NMIN = input.nmin;
+// Input for flags
+        flag[form_factors] = input.flag[input.form_factors];
+        flag[echo_input] = input.flag[input.echo_input];
+        flag[brems] = input.flag[input.brems];
+        flag[brems_add] = input.flag[input.brems_add];
+        flag[brems_hadr] = input.flag[input.brems_hadr];
+        flag[PS] = input.flag[input.PS];
+        flag[asymmetry] = input.flag[input.asymmetry];
+        flag[LO] = input.flag[input.LO];
+        flag[order] = input.flag[input.order];
+        flag[hadr_corr] = input.flag[input.hadr_corr];
+        flag[kappa_weak] = input.flag[input.kappa_weak];
+        flag[vac_pol] = input.flag[input.vac_pol];
+        flag[tpe] = input.flag[input.tpe];
+        flag[lepton] = input.flag[input.lepton];
+        flag[target] = input.flag[input.target];
+        flag[int_method] = input.flag[input.int_method];
+        flag[GL] = input.flag[input.GL];
+        flag[int_output] = input.flag[input.int_output];
+        flag[cuts_born] = input.flag[input.cuts_born];
+// Input for testing gamma_loop
+        Delta_eps = input.Delta_eps;
+        mu_dim = input.mu_dim;
+        lambda = input.lambda;
+// Input for event generator with variable energy
+        min[E] = input.E_min;
+        max[E] = input.E_max;
+        Delta_E = input.Delta_E;
+// Input for differential cross sections
+        thl = input.thl_deg * pi/180.;
+        thg = input.thg_deg * pi/180.;
+
+    }
+    
+    else {
+        ConfigFile CFile(input.input_file + ".in");
+        CFile.readInto<double>(en,"Incident Lepton Energy", input.E);
+        CFile.readInto<double>(min[theta_l_deg],"theta_l min", input.thl_min);
+        min[theta_l] = (min[theta_l_deg]*pi)/180.;
+        CFile.readInto<double>(max[theta_l_deg],"theta_l max", input.thl_max);
+        max[theta_l] = (max[theta_l_deg]*pi)/180.;
+        CFile.readInto<double>(min[Q2_elastic],"Q^2 min", input.Q2min);
+        CFile.readInto<double>(max[Q2_elastic],"Q^2 max", input.Q2max);
+        CFile.readInto<double>(min[E_gamma],"Delta", input.Delta);
+        CFile.readInto<double>(min[E_gamma_prime],"Delta", input.Delta);
+        CFile.readInto<double>(max[E_gamma],"E_gamma max", input.E_gamma_max);
+        CFile.readInto<double>(max[E_gamma_prime],"E_gamma max", input.E_gamma_max);
+        CFile.readInto<double>(min[E_p],"E_p min", input.E_p_min);
+        CFile.readInto<double>(min[E],"E min", input.E_min);
+        CFile.readInto<double>(max[E],"E max", input.E_max);
+        CFile.readInto<double>(Delta_E,"Delta E", input.Delta_E);
+        CFile.readInto<double>(min[theta_gamma_deg],"theta_gamma min", input.thg_min);
+        min[theta_gamma] = min[theta_gamma_deg]*pi/180.;
+        CFile.readInto<double>(max[theta_gamma_deg],"theta_gamma max", input.thg_max);
+        max[theta_gamma] = max[theta_gamma_deg]*pi/180.;
+        CFile.readInto<double>(min[E_prime],"E' min", input.E_prime_min);
+        CFile.readInto<double>(max[E_prime],"E' max", input.E_prime_max);
+        CFile.readInto<double>(P,"Polarization",input.polarization);
+        CFile.readInto<double>(sw2,"sin2thetaW",input.sw2);
+        CFile.readInto<double>(FLATNESS,"FLATNESS", input.flatness);
+        CFile.readInto<double>(SEED,"Seed", input.seed);
+        CFile.readInto<double>(EPSREL,"Relative Accuracy", input.epsrel);
+        CFile.readInto<double>(Delta_eps,"Delta_eps", input.Delta_eps);
+        CFile.readInto<double>(mu_dim,"mu_dim", input.mu_dim);
+        CFile.readInto<double>(lambda,"lambda", input.lambda);
+        CFile.readInto<int>(no_cores,"Number of cores", input.no_cores);
+        CFile.readInto<long long int>(MAXEVAL_LO,"Maximum Number of Evaluations LO", input.no_eval_LO);
+        CFile.readInto<long long int>(MAXEVAL_1st,"Maximum Number of Evaluations 1st", input.no_eval_1st);
+        CFile.readInto<long long int>(MAXEVAL_gamma_loop,"Maximum Number of Evaluations gamma_loop", input.no_eval_gamma_loop);
+        CFile.readInto<long long int>(MAXEVAL_2nd,"Maximum Number of Evaluations 2nd", input.no_eval_2nd);
+        CFile.readInto<long long int>(MAXEVAL_2nd_add,"Maximum Number of Evaluations 2nd sg finite", input.no_eval_2nd_add);
+        CFile.readInto<long long int>(MINEVAL,"Minimum Number of Evaluations", input.no_min_eval);
+        CFile.readInto<long long int>(NSTART,"NSTART", input.nstart);
+        CFile.readInto<long long int>(NINCREASE,"NINCREASE", input.nincrease);
+        CFile.readInto<long long int>(NBATCH,"NBATCH", input.nbatch);
+        CFile.readInto<long long int>(NNEW,"NNEW", input.nnew);
+        CFile.readInto<long long int>(NMIN,"NMIN", input.nmin);
+        CFile.readInto<int>(flag[form_factors], "Form Factors", input.flag[input.form_factors]);
+        CFile.readInto<int>(flag[echo_input], "Echo Input", input.flag[input.echo_input]);
+        CFile.readInto<int>(flag[brems], "Bremsstrahlung Type", input.flag[input.brems]);
+        CFile.readInto<int>(flag[Delta_cut], "Type of Delta Cut", input.flag[input.Delta_cut]);
+        CFile.readInto<int>(flag[brems_add], "Bremsstrahlung Add", input.flag[input.brems_add]);
+        CFile.readInto<int>(flag[brems_hadr], "Hadronic Radiation", input.flag[input.brems_hadr]);
+        CFile.readInto<int>(flag[hadr_corr], "Hadronic corrections", input.flag[input.hadr_corr]);
+        CFile.readInto<int>(flag[PS], "Phase Space Parametrization", input.flag[input.PS]);
+        CFile.readInto<int>(flag[asymmetry], "Asymmetry", input.flag[input.asymmetry]);
+        CFile.readInto<int>(flag[LO], "Leading Order", input.flag[input.LO]);
+        CFile.readInto<int>(flag[order], "Order SP_loop", input.flag[input.order]);
+        CFile.readInto<int>(flag[kappa_weak], "Kappa Form Factor", input.flag[input.kappa_weak]);
+        CFile.readInto<int>(flag[vac_pol], "Vacuum Polarization", input.flag[input.vac_pol]);
+        CFile.readInto<int>(flag[tpe], "Two-photon exchange", input.flag[input.tpe]);
+        CFile.readInto<int>(flag[lepton], "Incident Lepton", input.flag[input.lepton]);
+        CFile.readInto<int>(flag[target], "Target Particle", input.flag[input.target]);
+        CFile.readInto<int>(flag[int_method], "Integration method", input.flag[input.int_method]);
+        CFile.readInto<int>(flag[GL], "Gamma Loop", input.flag[input.GL]);
+        CFile.readInto<int>(flag[int_output],"Integration Output level", input.flag[input.int_output]);
+        CFile.readInto<int>(flag[cuts_born], "Type of Cuts", input.flag[input.cuts_born]);
+    }
+
+    return 0;
 }
+
 
 int Parameters::final_param(const Input& input) {
 
+// Check input for consitency
 	if (check_input == 0) {
 		std::cerr << "Warning! Input was not set!\n\n";
 		exit (EXIT_FAILURE);
 	}
 
 	if (flag[form_factors] < 0 || flag[form_factors] > 6) {
-		std::cerr<<"Warning! Wrong input for flag[form_factors]! Value changed to default!\n\n";
+		std::cerr << "Warning! Wrong input for flag[form_factors]! \n" 
+                  << "Value changed to default = 0 \n\n";
 		flag[form_factors] = 0;
 	}
 
 	if (flag[form_factors] > 4 && flag[target] == 0) {
-		std::cerr<<"Warning! Form factors for carbon-12 selected and "
-				"proton as target particle! Value changed to default\n\n";
+		std::cerr << "Warning! Form factor for carbon-12 selected \n" 
+                  << "but proton as target particle! \n" 
+                  << "Value changed to default flag[form_factors] = 0 \n\n";
 		flag[form_factors] = 0;
 	}
 
 	if (flag[form_factors] <= 4 && flag[target] == 1) {
-		std::cerr<<"Warning! Form factors for proton selected and "
-				"carbon-12 as target particle! Value changed to default\n\n";
+		std::cerr << "Warning! Form factors for proton selected \n"
+                  << "but carbon-12 as target particle! \n" 
+                  << "Value changed to default flag[form_factors] = 5 \n\n";
 		flag[form_factors] = 5;
 	}
 
 	if (flag[echo_input] < 0 || flag[echo_input] > 1) {
-		std::cerr<<"Warning! Wrong input for flag[echo_input]! Value changed to default!\n\n";
+		std::cerr << "Warning! Wrong input for flag[echo_input]! \n"
+                  << "Value changed to default = 0 \n\n";
 		flag[echo_input] = 0;
 	}
 
 	if (flag[brems] < 0 || flag[brems] > 15) {
-		std::cerr<<"Warning! Wrong input for flag[brems]! Value changed to default!\n\n";
+		std::cerr << "Warning! Wrong input for flag[brems]! \n" 
+                  << "Value changed to default flag[brems] = 0 \n\n";
 		flag[brems] = 0;
 	}
 	else if (flag[brems] > 3) {
-		std::cerr<<"Warning! This value inserted for flag[brems] is only for testing. "
-				"Use with care!\n\n";
+		std::cerr << "Warning! This value inserted for flag[brems] \n" 
+                  << "is only for testing. \n"
+				  << "Use with care! \n\n";
 	}
 
 	if (flag[brems_add] < 0 || flag[brems_add] > 1) {
-		std::cerr<<"Warning! Wrong input for flag[brems_add]! Value changed to default!\n\n";
+		std::cerr << "Warning! Wrong input for flag[brems_add]! \n" 
+                  << "Value changed to default 0 \n\n";
 		flag[brems_add] = 0;
 	}
 
 	if (flag[Delta_cut] < 0 || flag[Delta_cut] > 1) {
-		std::cerr<<"Warning! Wrong input for flag[Delta_cut]! Value changed to default!\n\n";
+		std::cerr << "Warning! Wrong input for flag[Delta_cut]! \n" 
+                  << "Value changed to default 0 \n\n";
 		flag[Delta_cut] = 0;
 	}
 
 	if (flag[brems_hadr] < 0 || flag[brems_hadr] > 3) {
-		std::cerr<<"Warning! Wrong input for flag[brems_hadr]! Value changed to default!\n\n";
+		std::cerr << "Warning! Wrong input for flag[brems_hadr]! \n"
+                  << "Value changed to default = 0 \n\n";
 		flag[brems_hadr] = 0;
 	}
 
 	if (flag[hadr_corr] < 0 || flag[hadr_corr] > 3) {
-		std::cerr<<"Warning! Wrong input for flag[brems_hadr]! Value changed to default!\n\n";
+		std::cerr << "Warning! Wrong input for flag[brems_hadr]! \n" 
+                  << "Value changed to default = 0 \n\n";
 		flag[brems_hadr] = 0;
 	}
 
 	if (flag[PS] < 0 || flag[PS] > 1) {
-		std::cerr<<"Warning! Wrong input for flag[PS]! Value changed to default!\n\n";
+		std::cerr << "Warning! Wrong input for flag[PS]! \n" 
+                  << "Value changed to default = 0 \n\n";
 		flag[PS] = 0;
 	}
 
 	if (flag[asymmetry] < 0 || flag[asymmetry] > 1) {
-		std::cerr<<"Warning! Wrong input for flag[asymmetry]! Value changed to default!\n\n";
+		std::cerr << "Warning! Wrong input for flag[asymmetry]! \n" 
+                  << "Value changed to default = 0 \n\n";
 		flag[asymmetry] = 0;
 	}
 
 	if (flag[LO] < 0 || flag[LO] > 1) {
-		std::cerr<<"Warning! Wrong input for flag[LO]! Value changed to default!\n\n";
+		std::cerr << "Warning! Wrong input for flag[LO]! \n" 
+                  << "Value changed to default = 0 \n\n";
 		flag[LO] = 0;
 	}
 
 	if (flag[order] < 0 || flag[order] > 2) {
-		std::cerr<<"Warning! Wrong input for flag[order]! Value changed to default!\n\n";
+		std::cerr << "Warning! Wrong input for flag[order]! \n" 
+                  << "Value changed to default = 0 \n\n";
 		flag[order] = 0;
 	}
 
 	if (flag[kappa_weak] < 0 || flag[kappa_weak] > 1) {
-		std::cerr<<"Warning! Wrong input for flag[kappa_weak]! Value changed to default!\n\n";
+		std::cerr << "Warning! Wrong input for flag[kappa_weak]! \n" 
+                  << "Value changed to default = 0 \n\n";
 		flag[kappa_weak] = 0;
 	}
 
 	if (flag[vac_pol] < 0 || flag[vac_pol] > 5) {
-		std::cerr<<"Warning! Wrong input for flag[vac_pol]! Value changed to default!\n\n";
+		std::cerr << "Warning! Wrong input for flag[vac_pol]! \n" 
+                  << "Value changed to default = 0 \n\n";
 		flag[vac_pol] = 0;
 	}
 
 	if (flag[tpe] < 0 || flag[tpe] > 2) {
-		std::cerr<<"Warning! Wrong input for flag[tpe]! Value changed to default!\n\n";
+		std::cerr << "Warning! Wrong input for flag[tpe]! \n" 
+                  << "Value changed to default = 0 \n\n";
 		flag[tpe] = 0;
 	}
 
 	if (flag[tpe] == 2 && en != 0.155) {
-		std::cerr<<"Warning! Option 2 fo flag[tpe] is valid only for E=155 MeV! "
-				"Value changed to default!\n\n";
+		std::cerr << "Warning! flag[tpe] = 2 is valid only for E=155 MeV! \n"
+                  << "Value changed to default = 0 \n\n";
 		flag[tpe] = 0;
 	}
 
 	if (flag[lepton] < 0 || flag[lepton] > 3) {
-		std::cerr<<"Warning! Wrong input for flag[lepton]! Value changed to default!\n\n";
+		std::cerr << "Warning! Wrong input for flag[lepton]! \n" 
+                  << "Value changed to default = 0 \n\n";
 		flag[lepton] = 0;
 	}
 
 	if (flag[target] < 0 || flag[target] > 2) {
-		std::cerr<<"Warning! Wrong input for flag[target]! Value changed to default!\n\n";
+		std::cerr << "Warning! Wrong input for flag[target]! \n" 
+                  << "Value changed to default = 0 \n\n";
 		flag[target] = 0;
 	}
 
 	if (flag[int_method] < 0 || flag[int_method] > 2) {
-		std::cerr<<"Warning! Wrong input for flag[int_method]! Value changed to default!\n\n";
+		std::cerr << "Warning! Wrong input for flag[int_method]! \n" 
+                  << "Value changed to default = 0 \n\n";
 		flag[int_method] = 0;
 	}
 
 	if (flag[GL] < 0 || flag[GL] > 1) {
-		std::cerr<<"Warning! Wrong input for flag[Gl]! Value changed to default!\n\n";
+		std::cerr << "Warning! Wrong input for flag[Gl]! \n" 
+                  << "Value changed to default = 0 \n\n";
 		flag[GL] = 0;
 	}
 
 	if (flag[int_output] < 0 || flag[int_output] > 2) {
-		std::cerr<<"Warning! Wrong input for flag[int_output]! Value changed to default!\n\n";
+		std::cerr << "Warning! Wrong input for flag[int_output]! \n" 
+                  << "Value changed to default = 0 \n\n";
 		flag[int_output] = 0;
 	}
 
 	if (flag[cuts_born] < 0 || flag[cuts_born] > 1) {
-		std::cerr<<"Warning! Wrong input for flag[cuts_born]! Value changed to default!\n\n";
+		std::cerr << "Warning! Wrong input for flag[cuts_born]! \n" 
+                  << "Value changed to default = 0 \n\n";
 		flag[cuts_born] = 0;
 	}
 
@@ -390,10 +354,13 @@ int Parameters::final_param(const Input& input) {
 	m2 = pow(m,2.);
 	M2 = pow(M,2.);
 
-//	if (en > 10.) std::cerr <<"Warning! Integration not tested for energies above "
-//			"10 GeV. Use with care!\n\n";
-	if (en <= 0.) {
-		std::cerr<<"Warning! Wrong input for E! Value changed to default!\n\n";
+//    if (en > 10.) 
+//        std::cerr << "Warning! Integration not tested for energies \n"
+//                  << "above 10 GeV. Use with care! \n\n";
+
+    if (en <= 0.) {
+		std::cerr << "Warning! Wrong input for E! \n" 
+                  << "Value changed to default E = 0.155 GeV \n\n";
 		en=0.155;
 	}
 
@@ -401,8 +368,8 @@ int Parameters::final_param(const Input& input) {
 		if ((min[theta_l_deg] < 0. || min[theta_l_deg] > 180.)
 				|| (max[theta_l_deg] < 0. || max[theta_l_deg] > 180.)
 				|| (max[theta_l_deg] <= min[theta_l_deg])) {
-			std::cerr<<"Warning! Wrong input for thl_min and/or thl_max! "
-					"Values changed to default!\n\n";
+			std::cerr << "Warning! Wrong input for thl_min and/or thl_max! \n"
+                      << "Values changed to default range 25-45 degrees \n\n";
 			min[theta_l_deg] = 25.;
 			min[theta_l] = 25.*pi/180.;
 			max[theta_l_deg] = 45.;
@@ -411,33 +378,41 @@ int Parameters::final_param(const Input& input) {
 	}
 	if (flag[cuts_born] == 1) {
 		double Q2max_abs = 4.*M2*(en*en-m2)/(M*(2.*en+M)+m2);
-		double Q2min = 4.*en*en*pow(sin(25.*pi/2./180.),2.)/(1.+2.*en*pow(sin(25.*pi/2./180.),2.)/M);
-		double Q2max = 4.*en*en*pow(sin(45.*pi/2./180.),2.)/(1.+2.*en*pow(sin(45.*pi/2./180.),2.)/M);
-		if (min[Q2_elastic] < 0. || max[Q2_elastic] > Q2max_abs || min[Q2_elastic] > max[Q2_elastic]) {
-			std::cerr<<"Warning! Wrong input for Q2_min and/or Q2_max! "
-					"Values changed to default!\n\n";
+		double Q2min = 
+            4.*en*en*pow(sin(25.*pi/2./180.),2.)
+            /(1.+2.*en*pow(sin(25.*pi/2./180.),2.)/M);
+		double Q2max = 
+            4.*en*en*pow(sin(45.*pi/2./180.),2.)
+            /(1.+2.*en*pow(sin(45.*pi/2./180.),2.)/M);
+		if (min[Q2_elastic] < 0. || max[Q2_elastic] > Q2max_abs 
+            || min[Q2_elastic] > max[Q2_elastic]) {
+			std::cerr << "Warning! Wrong input for Q2_min and/or Q2_max! \n"
+                      << "Values changed to default range corresponding to " 
+                      << "25-45 degrees scattering angle \n\n";
 			min[Q2_elastic] = Q2min;
 			max[Q2_elastic] = Q2max;
 		}
 	}
 
 	if (min[E_gamma] <= 0. || min[E_gamma] >= en - min[E_prime]) {
-		std::cerr<<"Warning! Wrong input for Delta! Value changed to default!\n\n";
+		std::cerr << "Warning! Wrong input for Delta! \n" 
+                  << "Value changed to default Delta = 0.01 \n\n";
 		min[E_gamma] = 0.01;
 		min[E_gamma_prime] = 0.01;
 	}
 	if (min[E_prime] < m || min[E_prime] >= en) {
-		std::cerr<<"Warning! Wrong input for E'min! Value changed to default!\n\n";
+		std::cerr << "Warning! Wrong input for E'min! \n" 
+                  << "Value changed to default E'min = m_electron \n\n";
 		min[E_prime] = m;
 	}
 	if (max[E_prime] > en - min[E_gamma] || max[E_prime] <= 0) {
-//		std::cerr<<"Warning! Wrong input for E'max! Value changed to default!";
 		max[E_prime] = en;
 	}
 	if (max[E_gamma] > en - min[E_prime]) max[E_gamma] = en - min[E_prime];
-	if (max[E_gamma] < min[E_gamma] || max[E_gamma] <= 0) max[E_gamma] = en - min[E_prime];
-	if (max[E_gamma_prime] < min[E_gamma_prime] || max[E_gamma_prime] <= 0) max[E_gamma_prime] = en - min[E_prime];
-
+	if (max[E_gamma] < min[E_gamma] || max[E_gamma] <= 0) 
+        max[E_gamma] = en - min[E_prime];
+	if (max[E_gamma_prime] < min[E_gamma_prime] || max[E_gamma_prime] <= 0) 
+        max[E_gamma_prime] = en - min[E_prime];
 	if (min[E_p] < M) min[E_p] = M;
 	if (max[E_p] > en + M) max [E_p] = en + M;
 
@@ -445,10 +420,7 @@ int Parameters::final_param(const Input& input) {
 	GRIDNO_brems_1st = 100000 + int(en*10000.);
 	GRIDNO_brems = 4;
 	GRIDNO_brems_test = 1;
-//	GRIDNO_brems_l1k = 700000 + int(en*10000.);
-//	GRIDNO_brems_l2k = 800000 + int(en*10000.);
 	GRIDNO_brems_interf = 3;
-//	GRIDNO_brems_2nd = 200000 + int(en*10000.);
 	GRIDNO_brems_2nd = 5;
 	GRIDNO_brems_2nd_l1k1 = 200000 + int(en*10000.);
 	GRIDNO_brems_2nd_l1k2 = 300000 + int(en*10000.);
@@ -465,112 +437,113 @@ int Parameters::final_param(const Input& input) {
 	GRIDNO_brems_hadr_interf = 7;
 
 	// HS(17.03.2017)
-	 if (P < -1.) P=-1.;
-	 if (P >  1.) P= 1.;
+    if (P < -1.) P=-1.;
+    if (P >  1.) P= 1.;
 	// HS-end
 
 	 if (sw2 <= 0.) {
-		 std::cerr<<"Warning! Wrong input for sin2thetaW! Value changed to default!\n\n";
+		 std::cerr << "Warning! Wrong input for sin2thetaW! \n" 
+                   << "Value changed to default = sw2_msbar \n\n";
 		 sw2 = sw2_msbar;
 	 }
 
-	 if (input.Delta_E != 0.0001 && input.Delta_E != 0.001 && input.Delta_E != 0.01) {
-		 std::cerr << "Warning! Initialization failed! The increment for the energy "
-				 "of the incident electron has to be 0.0001, 0.001 or 0.01 GeV";
+	 if (input.Delta_E != 0.0001 && input.Delta_E != 0.001 
+         && input.Delta_E != 0.01) {
+		 std::cerr << "Warning! Initialization failed! \n" 
+                   << "The increment for the energy of the incident electron \n" 
+                   << "has to be 0.0001, 0.001 or 0.01 GeV";
 		 exit (EXIT_FAILURE);
 	 }
-
-//	if (GRIDNO_elastic >= 1602) GRIDNO_elastic = 0;
-//	if (GRIDNO_brems >= 3602) GRIDNO_brems = 0;
 
 	l1 = sqrt(pow(en, 2.) - m2);
 
 	if (flag[cuts_born] == 0) {
 		if (min[theta_l_deg] > 90)
-			min[Q2_elastic] = -((2*(en - m)*(en + m)*M*(-M + en*(-1 + pow(cos(min[theta_l]),2))) -
-					2*pow(pow(cos(min[theta_l]),2)*pow(en - m,2)*pow(en + m,2)*M2*
-							((-1 + pow(cos(min[theta_l]),2))*m2 + M2),0.5))*pow(2*en*M
-									-(-1 + pow(cos(min[theta_l]),2))*pow(en,2) + pow(cos(min[theta_l]),2)*m2 + M2,-1));
+			min[Q2_elastic] = 
+            -((2*(en - m)*(en + m)*M*(-M + en*(-1 + pow(cos(min[theta_l]),2))) 
+               - 2*pow(pow(cos(min[theta_l]),2)*pow(en - m,2)*pow(en + m,2)*M2*
+                       ((-1 + pow(cos(min[theta_l]),2))*m2 + M2),0.5))*
+              pow(2*en*M-(-1 + pow(cos(min[theta_l]),2))*pow(en,2) 
+                  + pow(cos(min[theta_l]),2)*m2 + M2,-1));
 		else
-			min[Q2_elastic] = -2*((en - m)*(en + m)*M*(-M + en*(-1 + pow(cos(min[theta_l]),2))) +
-					pow(pow(cos(min[theta_l]),2)*pow(en - m,2)*pow(en + m,2)*M2*
-							((-1 + pow(cos(min[theta_l]),2))*m2 + M2),0.5))*pow(2*en*M
-									-(-1 + pow(cos(min[theta_l]),2))*pow(en,2) + pow(cos(min[theta_l]),2)*m2 + M2,-1);
+			min[Q2_elastic] = 
+            -2*((en - m)*(en + m)*M*(-M + en*(-1 + pow(cos(min[theta_l]),2))) 
+                + pow(pow(cos(min[theta_l]),2)*pow(en - m,2)*pow(en + m,2)*M2*
+                      ((-1 + pow(cos(min[theta_l]),2))*m2 + M2),0.5))*
+            pow(2*en*M-(-1 + pow(cos(min[theta_l]),2))*pow(en,2) 
+                + pow(cos(min[theta_l]),2)*m2 + M2,-1);
 
 		if (max[theta_l_deg] > 90)
-			max[Q2_elastic] = -((2*(en - m)*(en + m)*M*(-M + en*(-1 + pow(cos(max[theta_l]),2))) -
-					2*pow(pow(cos(max[theta_l]),2)*pow(en - m,2)*pow(en + m,2)*M2*
-							((-1 + pow(cos(max[theta_l]),2))*m2 + M2),0.5))* pow(2*en*M
-									-(-1 + pow(cos(max[theta_l]),2))*pow(en,2) + pow(cos(max[theta_l]),2)*m2 + M2,-1));
+			max[Q2_elastic] = 
+            -((2*(en - m)*(en + m)*M*(-M + en*(-1 + pow(cos(max[theta_l]),2))) 
+               - 2*pow(pow(cos(max[theta_l]),2)*pow(en - m,2)*pow(en + m,2)*M2*
+                       ((-1 + pow(cos(max[theta_l]),2))*m2 + M2),0.5))*
+              pow(2*en*M-(-1 + pow(cos(max[theta_l]),2))*pow(en,2) 
+                  + pow(cos(max[theta_l]),2)*m2 + M2,-1));
 		else
-			max[Q2_elastic] = -2*((en - m)*(en + m)*M*(-M + en*(-1 + pow(cos(max[theta_l]),2))) +
-					pow(pow(cos(max[theta_l]),2)*pow(en - m,2)*pow(en + m,2)*M2*
-							((-1 + pow(cos(max[theta_l]),2))*m2 + M2),0.5))*pow(2*en*M
-									-(-1 + pow(cos(max[theta_l]),2))*pow(en,2) + pow(cos(max[theta_l]),2)*m2 + M2,-1);
+			max[Q2_elastic] = 
+            -2*((en - m)*(en + m)*M*(-M + en*(-1 + pow(cos(max[theta_l]),2))) 
+                + pow(pow(cos(max[theta_l]),2)*pow(en - m,2)*pow(en + m,2)*M2*
+                      ((-1 + pow(cos(max[theta_l]),2))*m2 + M2),0.5))*
+            pow(2*en*M-(-1 + pow(cos(max[theta_l]),2))*pow(en,2) 
+                + pow(cos(max[theta_l]),2)*m2 + M2,-1);
 	}
 	else {
-		min[theta_l] = acos((-min[Q2_elastic] * (1. + en/M) + 2.*pow(en,2.) - 2.*m2) /
-				(2.*l1*sqrt(pow(en-min[Q2_elastic]/(2.*M),2.)-m2)));
+		min[theta_l] = 
+            acos((-min[Q2_elastic] * (1. + en/M) + 2.*pow(en,2.) - 2.*m2) / 
+            (2.*l1*sqrt(pow(en-min[Q2_elastic]/(2.*M),2.)-m2)));
 		min[theta_l_deg] = min[theta_l]*180./pi;
-		max[theta_l] = acos((-max[Q2_elastic] * (1. + en/M) + 2.*pow(en,2.) - 2.*m2) /
-				(2.*l1*sqrt(pow(en-max[Q2_elastic]/(2.*M),2.)-m2)));
+		max[theta_l] = 
+            acos((-max[Q2_elastic] * (1. + en/M) + 2.*pow(en,2.) - 2.*m2) / 
+            (2.*l1*sqrt(pow(en-max[Q2_elastic]/(2.*M),2.)-m2)));
 		max[theta_l_deg] = max[theta_l]*180./pi;
 	}
 
 	if (flag[tpe] != 0) {
 		eps = 1. / (1. + 2.*(1. + max[Q2_elastic]/(4.*M2))*pow(tan(max[theta_l]/2.),2.));
 		if (eps <= 1e-4) {
-			std::cerr<<"Warning! Epsilon is out of allowed range for interpolation. "
-					"The two-photon exchange correction is disabled \n\n";
+			std::cerr << "Warning! Epsilon is out of range for interpolation. \n"
+                      << "The two-photon exchange correction is disabled \n\n";
 			flag[tpe] = 0;
 		}
 
 		eps = 1. / (1. + 2.*(1. + min[Q2_elastic]/(4.*M2))*pow(tan(min[theta_l]/2.),2.));
 		if (eps >= 0.9999) {
-			std::cerr<<"Warning! Epsilon is out of allowed range for interpolation. "
-					"The two-photon exchange correction is disabled \n\n";
+			std::cerr << "Warning! Epsilon is out of range for interpolation. \n"
+                      << "The two-photon exchange correction is disabled \n\n";
 			flag[tpe] = 0;
 		}
 
 		if (max[Q2_elastic] >= 3 || min[Q2_elastic] <= 1e-7) {
-			std::cerr<<"Warning! Q^2 is out of allowed range for interpolation. "
-					"The two-photon exchange correction is disabled \n\n";
+			std::cerr << "Warning! Q^2 is out of range for interpolation. \n"
+                      << "The two-photon exchange correction is disabled \n\n";
 			flag[tpe] = 0;
 		}
 	}
 
 	if (flag[vac_pol] == 3) {
 		if (min[Q2_elastic] <= 0. || max[Q2_elastic] > 1e6) {
-			std::cerr<<"Warning! Q^2 is out of allowed range for interpolation."
-					" The hadronic vacuum polarization correction is disabled \n\n";
+			std::cerr << "Warning! Q^2 is out of range for interpolation. \n"
+                      << "Hadronic vacuum polarization correction is disabled \n\n";
 			flag[vac_pol] = 2;
 		}
 	}
 
 	if (flag[vac_pol] == 4) {
 		if (min[Q2_elastic] <= 0. || max[Q2_elastic] >= 1e6) {
-			std::cerr<<"Warning! Q^2 is out of allowed range for interpolation."
-					" The hadronic vacuum polarization correction is disabled \n\n";
+			std::cerr << "Warning! Q^2 is out of range for interpolation. \n"
+                      << "Hadronic vacuum polarization correction is disabled \n\n";
 			flag[vac_pol] = 2;
 		}
 	}
 
 	if (flag[vac_pol] == 5) {
 		if (min[Q2_elastic] <= 0. || max[Q2_elastic] >= 9992.0015999999996) {
-			std::cerr<<"Warning! Q^2 is out of allowed range for interpolation."
-					" The hadronic vacuum polarization correction is disabled \n\n";
+			std::cerr << "Warning! Q^2 is out of range for interpolation. \n"
+                      << "Hadronic vacuum polarization correction is disabled \n\n";
 			flag[vac_pol] = 2;
 		}
 	}
-
-//#ifndef POLARES_USE_LOOPTOOLS
-//	if (flag[order] == 2 && flag[GL] == 0) {
-//	std::cerr << "Warning! Second order corrections and exact calculation for 1loop*1HP selected, "
-//			"but Looptools was not included."
-//			" Please check the manual for how to include Looptools or select 'Gamma Loop=1' \n\n";
-//	exit (EXIT_FAILURE);
-//	}
-//#endif
 
 	if (flag[order] == 2 && flag[order] == 2) {
 		maxeval_1st_aux = MAXEVAL_1st;
@@ -584,8 +557,9 @@ int Parameters::final_param(const Input& input) {
 
 	output_file = input.input_file;
 
-		return 0;
+    return 0;
 }
+
 
 int Parameters::set_thl(const double thl_deg) {
 
@@ -607,25 +581,29 @@ int Parameters::set_thl(const double thl_deg) {
 	if (flag[tpe] != 0) {
 		eps = 1. / (1. + 2.*(1. + max[Q2_elastic]/(4.*M2))*pow(tan(max[theta_l]/2.),2.));
 		if (eps <= 1e-4) {
-			std::cerr<<"Warning! Epsilon is out of allowed range for interpolation. The two-photon exchange correction is disabled \n\n";
+			std::cerr << "Warning! Epsilon is out of range for interpolation. \n" 
+                      << "The two-photon exchange correction is disabled \n\n";
 			flag[tpe] = 0;
 		}
 
 		eps = 1. / (1. + 2.*(1. + min[Q2_elastic]/(4.*M2))*pow(tan(min[theta_l]/2.),2.));
 		if (eps >= 0.9999) {
-			std::cerr<<"Warning! Epsilon is out of allowed range for interpolation. The two-photon exchange correction is disabled \n\n";
+			std::cerr << "Warning! Epsilon is out of range for interpolation. \n" 
+                      << "The two-photon exchange correction is disabled \n\n";
 			flag[tpe] = 0;
 		}
 
 		if (max[Q2_elastic] >= 3 || min[Q2_elastic] <= 1e-7) {
-			std::cerr<<"Warning! Q^2 is out of allowed range for interpolation. The two-photon exchange correction is disabled \n\n";
+			std::cerr << "Warning! Q^2 is out of range for interpolation. \n" 
+                      << "The two-photon exchange correction is disabled \n\n";
 			flag[tpe] = 0;
 		}
 	}
 
 	if (flag[vac_pol] != 0) {
 		if (Q2 <= 4.6e-7 || Q2 > 1e6) {
-			std::cerr<<"Warning! Q^2 is out of allowed range for interpolation. The hadronic vacuum polarization correction is disabled \n\n";
+			std::cerr << "Warning! Q^2 is out of range for interpolation. \n" 
+                      << "Hadronic vacuum polarization correction is disabled \n\n";
 			flag[vac_pol] = 2;
 		}
 	}


### PR DESCRIPTION
24.02.2022
- parameters.cpp: white space
- parameters.cpp: changed output text
- POLARES.cpp: added write input of param.hadr_corr and
  param.brems_hadr for options 2 and 3

26.02.2022
- POLARES.cpp: added comments, removed commented code
- POLARES.cpp: added warning if order=2 and brems=1 from user input
- POLARES.cpp: cleaning white space
  and output text
- POLARES.cpp: added re-calculated 1st order elastic part if order=2
- POLARES.cpp: added calculation of asymmetry for case brems=0

05.03.2022
- POLARES.cpp: removed undocumented code for options
  brems=9, 10, 11, 12.
- POLARES.cpp: corrected output text for option hadronic vac-pol
- POLARES.cpp: replaced param.hadr_corr by param.brems_hadr to
  select hadronic bremsstrahlung corrections. Added warning if
  hadr_corr and brems_hadr differ.
- POLARES.cpp: changed output text and changed order of output
- POLARES.cpp: inserted abs() for error of asymmetries (many times)
- POLARES.cpp: re-ordered sections in PES::initialization()
- POLARES.cpp: lines 320 and 457: added case order=2 to keep
  1st order correction and de-activated section below

10.03.2022
- POLARES.cpp: more changes of output layout and text
- POLARES.cpp: use GRIDNO_brems_1st instead of GRIDNO_brems also
  when recalculating 1st order with order=2